### PR TITLE
Add moodle webview

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -88,5 +88,5 @@ dependencies {
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
     implementation 'com.android.support:multidex:1.0.3'
-    implementation("com.google.android.material:material:1.13.0-alpha05")
+    implementation 'com.google.android.material:material:1.12.0'
 }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -88,4 +88,5 @@ dependencies {
     implementation 'androidx.window:window:1.0.0'
     implementation 'androidx.window:window-java:1.0.0'
     implementation 'com.android.support:multidex:1.0.3'
+    implementation("com.google.android.material:material:1.13.0-alpha05")
 }

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -72,5 +72,9 @@
         <intent>
             <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="moodlemobile" />
+        </intent>
     </queries>
 </manifest>

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,16 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
+        <provider
+                android:name="com.pichillilorenzo.webview_inapp_android.InAppWebViewFileProvider"
+                android:authorities="${applicationId}.webview_inapp_android.fileprovider"
+                android:exported="false"
+                android:grantUriPermissions="true">
+            <meta-data
+                    android:name="android.support.FILE_PROVIDER_PATHS"
+                    android:resource="@xml/provider_paths" />
+        </provider>
+
         <service
                 android:name="dev.fluttercommunity.plus.androidalarmmanager.AlarmService"
                 android:permission="android.permission.BIND_JOB_SERVICE"
@@ -71,10 +81,6 @@
         <!-- If your application checks for inAppBrowserView launch mode support -->
         <intent>
             <action android:name="android.support.customtabs.action.CustomTabsService" />
-        </intent>
-        <intent>
-            <action android:name="android.intent.action.VIEW" />
-            <data android:scheme="moodlemobile" />
         </intent>
     </queries>
 </manifest>

--- a/app/android/app/src/main/res/values-night-v31/styles.xml
+++ b/app/android/app/src/main/res/values-night-v31/styles.xml
@@ -13,7 +13,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.Material3.Dark.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values-night-v31/styles.xml
+++ b/app/android/app/src/main/res/values-night-v31/styles.xml
@@ -13,7 +13,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="Theme.Material3.Dark.NoActionBar">
+    <style name="NormalTheme" parent="Theme.Material3.DynamicColors.Dark.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values-night/styles.xml
+++ b/app/android/app/src/main/res/values-night/styles.xml
@@ -16,7 +16,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Black.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values-night/styles.xml
+++ b/app/android/app/src/main/res/values-night/styles.xml
@@ -16,7 +16,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="Theme.Material3.DayNight.NoActionBar">
+    <style name="NormalTheme" parent="Theme.Material3.Dark.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values-v31/styles.xml
+++ b/app/android/app/src/main/res/values-v31/styles.xml
@@ -13,7 +13,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="Theme.Material3.Light.NoActionBar">
+    <style name="NormalTheme" parent="Theme.Material3.DynamicColors.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values-v31/styles.xml
+++ b/app/android/app/src/main/res/values-v31/styles.xml
@@ -13,7 +13,7 @@
          running.
          
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/android/app/src/main/res/values/styles.xml
+++ b/app/android/app/src/main/res/values/styles.xml
@@ -16,7 +16,7 @@
          running.
 
          This Theme is only used starting with V2 of Flutter's Android embedding. -->
-    <style name="NormalTheme" parent="@android:style/Theme.Light.NoTitleBar">
+    <style name="NormalTheme" parent="Theme.Material3.Light.NoActionBar">
         <item name="android:windowBackground">?android:colorBackground</item>
     </style>
 </resources>

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -34,6 +34,7 @@ class SPHclient {
   String schoolName = "";
 
   String? singleSignOnToken;
+  String? sessionToken;
 
   Map<String, String> userData = {};
   List<dynamic> travelMenu = [];
@@ -137,6 +138,13 @@ class SPHclient {
     try {
       String loginURL = await getLoginURL();
       await dio.get(loginURL);
+      final cookies = await client.jar
+          .loadForRequest(Uri.parse("https://start.schulportal.hessen.de"));
+      for (int i = 0; i < cookies.length; i++) {
+        if (cookies[i].name == "sid") {
+          sessionToken = cookies[i].value;
+        }
+      }
 
       preventLogoutTimer?.cancel();
       preventLogoutTimer = Timer.periodic(
@@ -356,12 +364,16 @@ class SPHclient {
       }
     }
 
+    dio.interceptors.removeWhere((element) => element is CookieManager);
     jar.deleteAll();
+    dio.interceptors.add(CookieManager(jar));
+
     globalStorage.deleteAll();
     ColorModeNotifier.set("standard", Themes.standardTheme);
     ThemeModeNotifier.set("system");
     substitutions.localFilter = {};
     singleSignOnToken = null;
+    sessionToken = null;
 
     var tempDir = await getTemporaryDirectory();
     await deleteSubfoldersAndFiles(tempDir);

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -361,6 +361,7 @@ class SPHclient {
     ColorModeNotifier.set("standard", Themes.standardTheme);
     ThemeModeNotifier.set("system");
     substitutions.localFilter = {};
+    singleSignOnToken = null;
 
     var tempDir = await getTemporaryDirectory();
     await deleteSubfoldersAndFiles(tempDir);

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -33,6 +33,8 @@ class SPHclient {
   String schoolID = "";
   String schoolName = "";
 
+  String? singleSignOnToken;
+
   Map<String, String> userData = {};
   List<dynamic> travelMenu = [];
   Timer? preventLogoutTimer;
@@ -244,6 +246,11 @@ class SPHclient {
             parse(response1.data).getElementById("authErrorLocktime");
 
         if (response1.headers.value(HttpHeaders.locationHeader) != null) {
+          if (singleSignOnToken == null) {
+            final String setCookie = response1.headers.map["set-cookie"]![0];
+            singleSignOnToken = setCookie.substring(setCookie.indexOf("=") + 1, setCookie.indexOf(";"));
+          }
+
           //credits are valid
           final response2 =
               await dioHttp.get("https://connect.schulportal.hessen.de");
@@ -355,6 +362,7 @@ class SPHclient {
     ColorModeNotifier.set("standard", Themes.standardTheme);
     ThemeModeNotifier.set("system");
     substitutions.localFilter = {};
+    singleSignOnToken = null;
 
     var tempDir = await getTemporaryDirectory();
     await deleteSubfoldersAndFiles(tempDir);

--- a/app/lib/client/client.dart
+++ b/app/lib/client/client.dart
@@ -247,8 +247,15 @@ class SPHclient {
 
         if (response1.headers.value(HttpHeaders.locationHeader) != null) {
           if (singleSignOnToken == null) {
-            final String setCookie = response1.headers.map["set-cookie"]![0];
-            singleSignOnToken = setCookie.substring(setCookie.indexOf("=") + 1, setCookie.indexOf(";"));
+            final List<String>? cookies = response1.headers.map["set-cookie"];
+
+            if (cookies != null) {
+              for (int i = 0; i < response1.headers.map["set-cookie"]!.length; i++) {
+                if (cookies[i].contains("SPH-Session")) {
+                  singleSignOnToken = cookies[i].substring(cookies[i].indexOf("=") + 1, cookies[i].indexOf(";"));
+                }
+              }
+            }
           }
 
           //credits are valid

--- a/app/lib/home_page.dart
+++ b/app/lib/home_page.dart
@@ -13,6 +13,7 @@ import 'package:sph_plan/view/calendar/calendar.dart';
 import 'package:sph_plan/view/conversations/overview.dart';
 import 'package:sph_plan/view/data_storage/data_storage.dart';
 import 'package:sph_plan/view/mein_unterricht/mein_unterricht.dart';
+import 'package:sph_plan/view/moodle.dart';
 import 'package:sph_plan/view/settings/settings.dart';
 import 'package:sph_plan/view/timetable/stream.dart';
 import 'package:sph_plan/view/substitutions/stream.dart';
@@ -110,6 +111,18 @@ class _HomePageState extends State<HomePage> {
                   builder: (context) => const DataStorageAnsicht()),
             )),
     Destination(
+        label: (context) => AppLocalizations.of(context)!.openMoodle,
+        icon: const Icon(Icons.open_in_new),
+        selectedIcon: const Icon(Icons.open_in_new),
+        isSupported: true,
+        enableBottomNavigation: false,
+        enableDrawer: true,
+        action: (context) => Navigator.push(
+            context,
+            MaterialPageRoute(
+                builder: (context) => Moodle())
+        )),
+    Destination(
         label: (context) => AppLocalizations.of(context)!.openLanisInBrowser,
         icon: const Icon(Icons.open_in_new),
         selectedIcon: const Icon(Icons.open_in_new),
@@ -121,15 +134,6 @@ class _HomePageState extends State<HomePage> {
             launchUrl(Uri.parse(response));
           });
         }),
-    Destination(
-        label: (context) => AppLocalizations.of(context)!.openMoodleLogin,
-        icon: const Icon(Icons.open_in_new),
-        selectedIcon: const Icon(Icons.open_in_new),
-        isSupported: true,
-        enableBottomNavigation: false,
-        enableDrawer: true,
-        action: (context) => launchUrl(
-            Uri.parse("https://mo${client.schoolID}.schulportal.hessen.de"))),
     Destination(
         label: (context) => AppLocalizations.of(context)!.settings,
         icon: const Icon(Icons.settings),

--- a/app/lib/home_page.dart
+++ b/app/lib/home_page.dart
@@ -120,7 +120,7 @@ class _HomePageState extends State<HomePage> {
         action: (context) => Navigator.push(
             context,
             MaterialPageRoute(
-                builder: (context) => MoodleWebView())
+                builder: (context) => const MoodleWebView())
         )),
     Destination(
         label: (context) => AppLocalizations.of(context)!.openLanisInBrowser,

--- a/app/lib/home_page.dart
+++ b/app/lib/home_page.dart
@@ -120,7 +120,7 @@ class _HomePageState extends State<HomePage> {
         action: (context) => Navigator.push(
             context,
             MaterialPageRoute(
-                builder: (context) => Moodle())
+                builder: (context) => MoodleWebView())
         )),
     Destination(
         label: (context) => AppLocalizations.of(context)!.openLanisInBrowser,

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -184,5 +184,6 @@
   "addSpecificFilter": "\"{filter}\" hinzufügen",
   "tryAgain": "Erneut versuchen",
   "refreshComplete": "Aktualisierung abgeschlossen",
-  "offline": "Offline"
+  "offline": "Offline",
+  "noAppToOpen": "Lanis-Mobile konnte keine App finden, um die angegebene Datei zu öffnen."
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -12,7 +12,7 @@
   "settings": "Einstellungen",
   "about": "Über Lanis-Mobile",
   "openLanisInBrowser": "Im Browser öffnen",
-  "openMoodleLogin": "Moodle Login öffnen",
+  "openMoodle": "Moodle öffnen",
   "userData": "Benutzerdaten",
   "personalSchoolSupport": "Unterstützung für deine Schule",
   "appearance": "Aussehen",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -12,7 +12,7 @@
   "settings": "Settings",
   "about": "About Lanis-Mobile",
   "openLanisInBrowser": "Open in Browser",
-  "openMoodleLogin": "Open Moodle Login",
+  "openMoodle": "Open Moodle",
   "userData": "Userdata",
   "personalSchoolSupport": "Personal school support",
   "appearance": "Appearance",

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -184,5 +184,6 @@
   "addSpecificFilter": "Add \"{filter}\"",
   "tryAgain": "Try again",
   "refreshComplete": "Refresh complete",
-  "offline": "Offline"
+  "offline": "Offline",
+  "noAppToOpen": "Lanis-Mobile could not find any App to open the specified File in."
 }

--- a/app/lib/shared/launch_file.dart
+++ b/app/lib/shared/launch_file.dart
@@ -4,6 +4,8 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../client/client.dart';
+import '../client/logger.dart';
+
 
 void launchFile(BuildContext context, String url, String filename,
     String? filesize, Function callback) {
@@ -20,7 +22,7 @@ void launchFile(BuildContext context, String url, String filename,
         );
       });
 
-  client.downloadFile(url, filename).then((filepath) {
+  client.downloadFile(url, filename).then((filepath) async {
     Navigator.of(context).pop();
 
     if (filepath == "") {
@@ -53,7 +55,27 @@ void launchFile(BuildContext context, String url, String filename,
                 ],
               ));
     } else {
-      OpenFile.open(filepath);
+      final result = await OpenFile.open(filepath);
+      logger.i(result.message);
+      //sketchy, but "open_file" left us no other choice
+      if (result.message.contains("No APP found to open this file")) {
+        showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+                  title: Text("${AppLocalizations.of(context)!.error}!"),
+                  icon: const Icon(Icons.error),
+                  content: Text(
+                      AppLocalizations.of(context)!.noAppToOpen),
+                  actions: [
+                    FilledButton(
+                      child: const Text('Ok'),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  ],
+                ));
+      }
       callback(); // Call the callback function after the file is opened
     }
   });

--- a/app/lib/shared/launch_file.dart
+++ b/app/lib/shared/launch_file.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:open_file/open_file.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../client/client.dart';
 
@@ -17,6 +19,7 @@ void launchFile(BuildContext context, String url, String filename,
           ),
         );
       });
+
   client.downloadFile(url, filename).then((filepath) {
     Navigator.of(context).pop();
 
@@ -24,12 +27,25 @@ void launchFile(BuildContext context, String url, String filename,
       showDialog(
           context: context,
           builder: (context) => AlertDialog(
-                title: const Text("Fehler!"),
+                title: Text("${AppLocalizations.of(context)!.error}!"),
+                icon: const Icon(Icons.error),
                 content: Text(
-                    "Beim Download der Datei $filename ist ein unerwarteter Fehler aufgetreten. Wenn dieses Problem besteht, senden Sie uns bitte einen Fehlerbericht."),
+                    AppLocalizations.of(context)!.reportError),
                 actions: [
                   TextButton(
-                    child: const Text('OK'),
+                      onPressed: () {
+                        launchUrl(Uri.parse("https://github.com/alessioC42/lanis-mobile/issues"));
+                      },
+                      child: const Text("GitHub")
+                  ),
+                  OutlinedButton(
+                      onPressed: () {
+                        launchUrl(Uri.parse("mailto:alessioc42.dev@gmail.com"));
+                      },
+                      child: Text(AppLocalizations.of(context)!.startupReportButton)
+                  ),
+                  FilledButton(
+                    child: const Text('Ok'),
                     onPressed: () {
                       Navigator.of(context).pop();
                     },

--- a/app/lib/shared/widgets/error_view.dart
+++ b/app/lib/shared/widgets/error_view.dart
@@ -62,7 +62,13 @@ class ErrorView extends StatelessWidget {
                         const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
               ),
               if (error is! NoConnectionException) ...[
-                Text("Problem: ${error.cause}"),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 8.0),
+                  child: Text(
+                      "Problem: ${error.cause}",
+                    textAlign: TextAlign.center,
+                  ),
+                ),
               ],
               const SizedBox(height: 24,),
               if (retry != null) FilledButton(

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -4,56 +4,202 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../client/client.dart';
 
-class Moodle extends StatefulWidget {
-  const Moodle({Key? key}) : super(key: key);
+class MoodleWebView extends StatefulWidget {
+  const MoodleWebView({super.key});
 
   @override
-  _MoodleState createState() => _MoodleState();
+  State<MoodleWebView> createState() => _MoodleWebViewState();
 }
 
-class _MoodleState extends State<Moodle> {
+class _MoodleWebViewState extends State<MoodleWebView> {
+  ValueNotifier<bool> canGoBack = ValueNotifier(false);
+  ValueNotifier<bool> canGoForward = ValueNotifier(false);
+  ValueNotifier<int> progressIndicator = ValueNotifier(0);
+
   InAppWebViewController? webViewController;
+   PullToRefreshController? pullToRefreshController;
 
   @override
   void initState() {
     super.initState();
 
     String sessionToken = "";
-    client.jar.loadForRequest(Uri.parse("https://start.schulportal.hessen.de")).then((cookies) {
+    client.jar
+        .loadForRequest(Uri.parse("https://start.schulportal.hessen.de"))
+        .then((cookies) {
       sessionToken = cookies[1].value;
     });
 
     CookieManager cookieManager = CookieManager.instance();
     cookieManager.deleteAllCookies();
 
-    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "SPH-Session", value: client.singleSignOnToken!, isSecure: true, domain: ".hessen.de");
-    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "sid", value: sessionToken, isSecure: true, domain: ".hessen.de");
-    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "i", value: "6091", isSecure: true, domain: ".hessen.de");
+    cookieManager.setCookie(
+        url: WebUri("https://schulportal.hessen.de"),
+        name: "SPH-Session",
+        value: client.singleSignOnToken!,
+        isSecure: true,
+        domain: ".hessen.de");
+    cookieManager.setCookie(
+        url: WebUri("https://schulportal.hessen.de"),
+        name: "sid",
+        value: sessionToken,
+        isSecure: true,
+        domain: ".hessen.de");
+    cookieManager.setCookie(
+        url: WebUri("https://schulportal.hessen.de"),
+        name: "i",
+        value: "6091",
+        isSecure: true,
+        domain: ".hessen.de");
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    pullToRefreshController ??= PullToRefreshController(
+        settings: PullToRefreshSettings(
+          color: Theme.of(context).colorScheme.primary,
+          backgroundColor: Theme.of(context).colorScheme.surfaceContainer
+        ),
+          onRefresh: () async {
+            webViewController?.reload();
+          });
+
+    pullToRefreshController!.setColor(Theme.of(context).colorScheme.primary);
+    pullToRefreshController!.setBackgroundColor(Theme.of(context).colorScheme.surfaceContainer);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
-      body: InAppWebView(
-        initialSettings: InAppWebViewSettings(),
-        initialUrlRequest:
-          URLRequest(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de")),
-        onWebViewCreated: (controller) {
-          webViewController = controller;
-        },
-        shouldOverrideUrlLoading: (controller, navigationAction) async {
-          final WebUri uri = navigationAction.request.url!;
+      appBar: AppBar(
+        title: const Text("Moodle"),
+      ),
+      body: Stack(
+        children: [
+          InAppWebView(
+            pullToRefreshController: pullToRefreshController,
+            initialUrlRequest: URLRequest(
+                url: WebUri(
+                    "https://mo${client.schoolID}.schulportal.hessen.de")),
+            initialSettings: InAppWebViewSettings(transparentBackground: true),
+            onWebViewCreated: (controller) {
+              webViewController = controller;
+            },
+            shouldOverrideUrlLoading: (controller, navigationAction) async {
+              final WebUri uri = navigationAction.request.url!;
 
-          if (!uri.rawValue.contains(".schulportal.hessen.de")) {
-            await launchUrl(uri);
+              if (uri.rawValue.contains(".schulportal.hessen.de/login/logout.php") || uri.rawValue.contains(".schulportal.hessen.de/index.php?logout=all")) {
+                return NavigationActionPolicy.CANCEL;
+              }
 
-            return NavigationActionPolicy.CANCEL;
-          }
+              if (!uri.rawValue.contains(".schulportal.hessen.de")) {
+                await launchUrl(uri);
 
-          return NavigationActionPolicy.ALLOW;
-        },
-      )
+                return NavigationActionPolicy.CANCEL;
+              }
+
+              return NavigationActionPolicy.ALLOW;
+            },
+            onLoadStart: (controller, uri) async {
+              if (await controller.canGoBack()) {
+                canGoBack.value = true;
+              } else {
+                canGoBack.value = false;
+              }
+
+              if (await controller.canGoForward()) {
+                canGoForward.value = true;
+              } else {
+                canGoForward.value = false;
+              }
+            },
+            onLoadStop: (controller, url) {
+              pullToRefreshController!.endRefreshing();
+              progressIndicator.value = 0;
+
+              // Hack to enable pull to refresh in Moodle.
+              controller.evaluateJavascript(
+                  source:
+                      "document.documentElement.style.height = document.documentElement.clientHeight + 1 + 'px';");
+
+              // Hide logout buttons.
+              controller.evaluateJavascript(
+                  source: '''document.querySelector("div#user-action-menu a.dropdown-item[href*='/login/logout.php']").style.display = "none";'''
+              );
+              controller.evaluateJavascript(
+                  source: '''document.querySelector("div.navbar li a[href*='index.php?logout=']").style.display = "none";'''
+              );
+            },
+            onProgressChanged: (controller, progress) {
+              if (progress == 100) {
+                pullToRefreshController!.endRefreshing();
+                progressIndicator.value = 0;
+                return;
+              }
+
+              progressIndicator.value = progress;
+            },
+            onReceivedError: (controller, request, error) {
+              pullToRefreshController!.endRefreshing();
+              progressIndicator.value = 0;
+            },
+          ),
+        ],
+      ),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ValueListenableBuilder(
+              valueListenable: progressIndicator,
+              builder: (context, progress, _) {
+                return Visibility(
+                  visible: progress != 0,
+                  maintainSize: true,
+                  maintainState: true,
+                  maintainAnimation: true,
+                  child: LinearProgressIndicator(
+                    value: progress / 100,
+                  ),
+                );
+              }),
+          Row(
+            children: [
+              IconButton(
+                  onPressed: () {
+                    if (webViewController != null) {
+                      webViewController!.reload();
+                    }
+                  },
+                  icon: const Icon(Icons.refresh)),
+              const Spacer(),
+              ValueListenableBuilder(
+                  valueListenable: canGoBack,
+                  builder: (context, can, _) {
+                    return IconButton(
+                        onPressed: can
+                            ? () {
+                                webViewController?.goBack();
+                              }
+                            : null,
+                        icon: const Icon(Icons.arrow_back));
+                  }),
+              ValueListenableBuilder(
+                  valueListenable: canGoForward,
+                  builder: (context, can, _) {
+                    return IconButton(
+                        onPressed: can
+                            ? () {
+                                webViewController?.goForward();
+                              }
+                            : null,
+                        icon: const Icon(Icons.arrow_forward));
+                  }),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -17,6 +17,8 @@ class MoodleWebView extends StatefulWidget {
 }
 
 class _MoodleWebViewState extends State<MoodleWebView> {
+  static CookieManager cookieManager = CookieManager.instance();
+
   ValueNotifier<bool> canGoBack = ValueNotifier(false);
   ValueNotifier<bool> canGoForward = ValueNotifier(false);
   ValueNotifier<int> progressIndicator = ValueNotifier(0);
@@ -29,7 +31,6 @@ class _MoodleWebViewState extends State<MoodleWebView> {
   bool firstPageLoaded = false;
 
   Future<void> setCookies() async {
-    CookieManager cookieManager = CookieManager.instance();
     cookieManager.deleteAllCookies();
 
     cookieManager.setCookie(
@@ -182,22 +183,37 @@ class _MoodleWebViewState extends State<MoodleWebView> {
                               },
                               onLoadStop: (controller, url) async {
                                 if (!firstPageLoaded) {
-                                  final moodleCookie1 = await CookieManager.instance().getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "MoodleSession");
-                                  final dioCookie1 = dio.Cookie(moodleCookie1!.name, moodleCookie1.value);
+                                  final moodleCookie1 = await cookieManager.getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "MoodleSession");
+                                  if (moodleCookie1 == null) {
+                                    error.value =
+                                    "Der Moodle-Session-Token konnte nicht abgeruft werden!";
+                                    hideWebView.value = true;
+                                    return;
+                                  }
+
+                                  final dioCookie1 = dio.Cookie(moodleCookie1.name, moodleCookie1.value);
                                   dioCookie1.httpOnly = false;
                                   dioCookie1.secure = true;
                                   dioCookie1.domain = "mo${client.schoolID}.schulportal.hessen.de";
                                   dioCookie1.path = "/";
 
-                                  final moodleCookie2 = await CookieManager.instance().getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "MOODLEID1_");
+                                  final moodleCookie2 = await cookieManager.getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "MOODLEID1_");
+                                  // Can't check if moodleCookie2 is null bc for some reason it's always null but it isn't.
                                   final dioCookie2 = dio.Cookie(moodleCookie2!.name, moodleCookie2.value);
                                   dioCookie2.httpOnly = false;
                                   dioCookie2.secure = true;
                                   dioCookie2.domain = "mo${client.schoolID}.schulportal.hessen.de";
                                   dioCookie2.path = "/";
 
-                                  final moodleCookie3 = await CookieManager.instance().getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "mo-prod01");
-                                  final dioCookie3 = dio.Cookie(moodleCookie3!.name, moodleCookie3.value);
+                                  final moodleCookie3 = await cookieManager.getCookie(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de"), name: "mo-prod01");
+                                  if (moodleCookie3 == null) {
+                                    error.value =
+                                    "Der 'mo-prod01' Cookie konnte nicht abgeruft werden!";
+                                    hideWebView.value = true;
+                                    return;
+                                  }
+
+                                  final dioCookie3 = dio.Cookie(moodleCookie3.name, moodleCookie3.value);
                                   dioCookie3.httpOnly = true;
                                   dioCookie3.secure = true;
                                   dioCookie3.domain = ".hessen.de";

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -118,8 +118,14 @@ class _MoodleWebViewState extends State<MoodleWebView> {
                       builder: (context, hide, _) {
                         return PopScope(
                           canPop: false,
-                          onPopInvoked: (_) async {
-                            webViewController!.goBack();
+                          onPopInvokedWithResult: (bool res, _) async {
+                            final canGoBack = await webViewController!.canGoBack();
+                            if (canGoBack) {
+                              webViewController!.goBack();
+                            } else {
+                              hideWebView.value = true;
+                              Navigator.of(context).pop();
+                            }
                           },
                           child: Visibility(
                             visible: !hide,

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:sph_plan/shared/exceptions/client_status_exceptions.dart';
 import 'package:webview_inapp/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../client/client.dart';
+import '../shared/widgets/error_view.dart';
 
 class MoodleWebView extends StatefulWidget {
   const MoodleWebView({super.key});
@@ -17,20 +19,27 @@ class _MoodleWebViewState extends State<MoodleWebView> {
   ValueNotifier<bool> canGoForward = ValueNotifier(false);
   ValueNotifier<int> progressIndicator = ValueNotifier(0);
   ValueNotifier<bool> hideWebView = ValueNotifier(false);
+  ValueNotifier<String?> error = ValueNotifier(null);
 
   InAppWebViewController? webViewController;
   PullToRefreshController? pullToRefreshController;
 
-  @override
-  void initState() {
-    super.initState();
+  Future<void> setCookies() async {
+    final cookies = await client.jar
+        .loadForRequest(Uri.parse("https://start.schulportal.hessen.de"));
+    String? sessionToken;
+    for (int i = 0; i < cookies.length; i++) {
+      if (cookies[i].name == "sid") {
+        sessionToken = cookies[i].value;
+      }
+    }
 
-    String sessionToken = "";
-    client.jar
-        .loadForRequest(Uri.parse("https://start.schulportal.hessen.de"))
-        .then((cookies) {
-      sessionToken = cookies[1].value;
-    });
+    if (sessionToken == null) {
+      error.value =
+          "Der Session-Token der jetzigen Sitzung konnte nicht abgerufen werden!";
+      hideWebView.value = true;
+      return;
+    }
 
     CookieManager cookieManager = CookieManager.instance();
     cookieManager.deleteAllCookies();
@@ -50,9 +59,22 @@ class _MoodleWebViewState extends State<MoodleWebView> {
     cookieManager.setCookie(
         url: WebUri("https://schulportal.hessen.de"),
         name: "i",
-        value: "6091",
+        value: client.schoolID,
         isSecure: true,
         domain: ".hessen.de");
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    if (client.singleSignOnToken == null) {
+      error.value = "Der SSO-Token konnte nicht abgerufen werden!";
+      hideWebView.value = true;
+      return;
+    }
+
+    progressIndicator.value = 1;
   }
 
   @override
@@ -75,159 +97,183 @@ class _MoodleWebViewState extends State<MoodleWebView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("Moodle"),
-        leading: IconButton(
-            onPressed: () async {
-              hideWebView.value = true;
-              Navigator.of(context).pop();
-            },
-            icon: const Icon(Icons.arrow_back)
+        appBar: AppBar(
+          title: const Text("Moodle"),
+          leading: IconButton(
+              onPressed: () async {
+                hideWebView.value = true;
+                Navigator.of(context).pop();
+              },
+              icon: const Icon(Icons.arrow_back)),
         ),
-      ),
-      body: Stack(
-        children: [
-          ValueListenableBuilder(
-            valueListenable: hideWebView,
-            builder: (context, hide, _) {
-              return Visibility(
-                visible: !hide,
-                child: InAppWebView(
-                  pullToRefreshController: pullToRefreshController,
-                  initialUrlRequest: URLRequest(
-                      url: WebUri(
-                          "https://mo${client.schoolID}.schulportal.hessen.de")),
-                  initialSettings: InAppWebViewSettings(transparentBackground: true),
-                  onWebViewCreated: (controller) {
-                    webViewController = controller;
-                  },
-                  shouldOverrideUrlLoading: (controller, navigationAction) async {
-                    final WebUri uri = navigationAction.request.url!;
+        body: Stack(
+          children: [
+            ValueListenableBuilder(
+                valueListenable: error,
+                builder: (context, _error, _) {
+                  return _error != null
+                      ? ErrorView(error: LanisException(_error), name: "Moodle")
+                      : const SizedBox.shrink();
+                }),
+            FutureBuilder(
+                future: setCookies(),
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState != ConnectionState.done) {
+                    return const SizedBox.shrink();
+                  }
 
-                    if (uri.rawValue
-                            .contains(".schulportal.hessen.de/login/logout.php") ||
-                        uri.rawValue.contains(
-                            ".schulportal.hessen.de/index.php?logout=all")) {
-                      return NavigationActionPolicy.CANCEL;
-                    }
+                  return ValueListenableBuilder(
+                      valueListenable: hideWebView,
+                      builder: (context, hide, _) {
+                        return Visibility(
+                          visible: !hide,
+                          child: InAppWebView(
+                            pullToRefreshController: pullToRefreshController,
+                            initialUrlRequest: URLRequest(
+                                url: WebUri(
+                                    "https://mo${client.schoolID}.schulportal.hessen.de")),
+                            initialSettings: InAppWebViewSettings(
+                                transparentBackground: true),
+                            onWebViewCreated: (controller) {
+                              webViewController = controller;
+                            },
+                            shouldOverrideUrlLoading:
+                                (controller, navigationAction) async {
+                              final WebUri uri = navigationAction.request.url!;
 
-                    if (!uri.rawValue.contains(".schulportal.hessen.de")) {
-                      await launchUrl(uri);
-
-                      return NavigationActionPolicy.CANCEL;
-                    }
-
-                    return NavigationActionPolicy.ALLOW;
-                  },
-                  onLoadStart: (controller, uri) async {
-                    if (await controller.canGoBack()) {
-                      canGoBack.value = true;
-                    } else {
-                      canGoBack.value = false;
-                    }
-
-                    if (await controller.canGoForward()) {
-                      canGoForward.value = true;
-                    } else {
-                      canGoForward.value = false;
-                    }
-                  },
-                  onLoadStop: (controller, url) {
-                    pullToRefreshController!.endRefreshing();
-                    progressIndicator.value = 0;
-                  },
-                  onPageCommitVisible: (controller, uri) {
-                    // Hack to enable pull to refresh in Moodle.
-                    controller.evaluateJavascript(
-                        source:
-                            "document.documentElement.style.height = document.documentElement.clientHeight + 1 + 'px';");
-
-                    // Hide logout buttons.
-                    controller.evaluateJavascript(
-                        source:
-                            '''document.querySelector("div#user-action-menu a.dropdown-item[href*='/login/logout.php']").style.display = "none";''');
-                    controller.evaluateJavascript(
-                        source:
-                            '''document.querySelector("div.navbar li a[href*='index.php?logout=']").style.display = "none";''');
-                  },
-                  onProgressChanged: (controller, progress) {
-                    if (progress == 100) {
-                      pullToRefreshController!.endRefreshing();
-                      progressIndicator.value = 0;
-                      return;
-                    }
-
-                    progressIndicator.value = progress;
-                  },
-                  onReceivedError: (controller, request, error) {
-                    pullToRefreshController!.endRefreshing();
-                    progressIndicator.value = 0;
-                  },
-                ),
-              );
-            }
-          ),
-        ],
-      ),
-      bottomNavigationBar: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          ValueListenableBuilder(
-              valueListenable: progressIndicator,
-              builder: (context, progress, _) {
-                return Visibility(
-                  visible: progress != 0,
-                  maintainSize: true,
-                  maintainState: true,
-                  maintainAnimation: true,
-                  child: LinearProgressIndicator(
-                    value: progress / 100,
-                  ),
-                );
-              }),
-          Row(
-            children: [
-              IconButton(
-                  onPressed: () {
-                    if (webViewController != null) {
-                      webViewController!.reload();
-                    }
-                  },
-                  icon: const Icon(Icons.refresh)),
-              IconButton(
-                  onPressed: () async {
-                    if (webViewController != null) {
-                      await Clipboard.setData(ClipboardData(text: (await webViewController!.getUrl())!.rawValue));
-                    }
-                  },
-                  icon: const Icon(Icons.link)),
-              const Spacer(),
-              ValueListenableBuilder(
-                  valueListenable: canGoBack,
-                  builder: (context, can, _) {
-                    return IconButton(
-                        onPressed: can
-                            ? () {
-                                webViewController?.goBack();
+                              if (uri.rawValue.contains(
+                                      ".schulportal.hessen.de/login/logout.php") ||
+                                  uri.rawValue.contains(
+                                      ".schulportal.hessen.de/index.php?logout=all")) {
+                                return NavigationActionPolicy.CANCEL;
                               }
-                            : null,
-                        icon: const Icon(Icons.arrow_back));
-                  }),
-              ValueListenableBuilder(
-                  valueListenable: canGoForward,
-                  builder: (context, can, _) {
-                    return IconButton(
-                        onPressed: can
-                            ? () {
-                                webViewController?.goForward();
+
+                              if (!uri.rawValue
+                                  .contains(".schulportal.hessen.de")) {
+                                await launchUrl(uri);
+
+                                return NavigationActionPolicy.CANCEL;
                               }
-                            : null,
-                        icon: const Icon(Icons.arrow_forward));
-                  }),
-            ],
-          ),
-        ],
-      ),
-    );
+
+                              return NavigationActionPolicy.ALLOW;
+                            },
+                            onLoadStart: (controller, uri) async {
+                              if (await controller.canGoBack()) {
+                                canGoBack.value = true;
+                              } else {
+                                canGoBack.value = false;
+                              }
+
+                              if (await controller.canGoForward()) {
+                                canGoForward.value = true;
+                              } else {
+                                canGoForward.value = false;
+                              }
+                            },
+                            onLoadStop: (controller, url) {
+                              pullToRefreshController!.endRefreshing();
+                              progressIndicator.value = 0;
+                            },
+                            onPageCommitVisible: (controller, uri) {
+                              // Hack to enable pull to refresh in Moodle.
+                              controller.evaluateJavascript(
+                                  source:
+                                      "document.documentElement.style.height = document.documentElement.clientHeight + 1 + 'px';");
+
+                              // Hide logout buttons.
+                              controller.evaluateJavascript(
+                                  source:
+                                      '''document.querySelector("div#user-action-menu a.dropdown-item[href*='/login/logout.php']").style.display = "none";''');
+                              controller.evaluateJavascript(
+                                  source:
+                                      '''document.querySelector("div.navbar li a[href*='index.php?logout=']").style.display = "none";''');
+                            },
+                            onProgressChanged: (controller, progress) {
+                              if (progress == 100) {
+                                pullToRefreshController!.endRefreshing();
+                                progressIndicator.value = 0;
+                                return;
+                              }
+
+                              progressIndicator.value = progress;
+                            },
+                            onReceivedError: (controller, request, error) {
+                              pullToRefreshController!.endRefreshing();
+                              progressIndicator.value = 0;
+                            },
+                          ),
+                        );
+                      });
+                }),
+          ],
+        ),
+        bottomNavigationBar: ValueListenableBuilder(
+          valueListenable: error,
+          builder: (context, _error, _) {
+            return _error == null
+                ? Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      ValueListenableBuilder(
+                          valueListenable: progressIndicator,
+                          builder: (context, progress, _) {
+                            return Visibility(
+                              visible: progress != 0,
+                              maintainSize: true,
+                              maintainState: true,
+                              maintainAnimation: true,
+                              child: LinearProgressIndicator(
+                                value: progress / 100,
+                              ),
+                            );
+                          }),
+                      Row(
+                        children: [
+                          IconButton(
+                              onPressed: () {
+                                if (webViewController != null) {
+                                  webViewController!.reload();
+                                }
+                              },
+                              icon: const Icon(Icons.refresh)),
+                          IconButton(
+                              onPressed: () async {
+                                if (webViewController != null) {
+                                  await Clipboard.setData(ClipboardData(
+                                      text: (await webViewController!.getUrl())!
+                                          .rawValue));
+                                }
+                              },
+                              icon: const Icon(Icons.link)),
+                          const Spacer(),
+                          ValueListenableBuilder(
+                              valueListenable: canGoBack,
+                              builder: (context, can, _) {
+                                return IconButton(
+                                    onPressed: can
+                                        ? () {
+                                            webViewController?.goBack();
+                                          }
+                                        : null,
+                                    icon: const Icon(Icons.arrow_back));
+                              }),
+                          ValueListenableBuilder(
+                              valueListenable: canGoForward,
+                              builder: (context, can, _) {
+                                return IconButton(
+                                    onPressed: can
+                                        ? () {
+                                            webViewController?.goForward();
+                                          }
+                                        : null,
+                                    icon: const Icon(Icons.arrow_forward));
+                              }),
+                        ],
+                      ),
+                    ],
+                  )
+                : const SizedBox.shrink();
+          },
+        ));
   }
 }

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:webview_inapp/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../client/client.dart';
@@ -17,7 +17,7 @@ class _MoodleWebViewState extends State<MoodleWebView> {
   ValueNotifier<int> progressIndicator = ValueNotifier(0);
 
   InAppWebViewController? webViewController;
-   PullToRefreshController? pullToRefreshController;
+  PullToRefreshController? pullToRefreshController;
 
   @override
   void initState() {

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:webview_inapp/flutter_inappwebview.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 import '../client/client.dart';
 
@@ -75,6 +76,64 @@ class _MoodleWebViewState extends State<MoodleWebView> {
     return Scaffold(
       appBar: AppBar(
         title: const Text("Moodle"),
+        actions: [
+          IconButton(
+              onPressed: () async {
+                if (await canLaunchUrl(Uri.parse("moodlemobile://https://${client.username}@mo${client.schoolID}.schulportal.hessen.de"))) {
+                  showDialog(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          icon: const Icon(Icons.warning),
+                          title: Text("In der Moodle App öffnen"),
+                          content: Text("Möglicherweise könnte deine Schule inkompatibel mit der App sein!"),
+                          actions: [
+                            OutlinedButton(
+                                onPressed: () {
+                                  Navigator.of(context).pop();
+                                },
+                                child: Text(AppLocalizations.of(context)!.back)
+                            ),
+                            FilledButton(
+                                onPressed: () {
+                                  launchUrl(Uri.parse("moodlemobile://https://${client.username}@mo${client.schoolID}.schulportal.hessen.de"));
+                                  Navigator.of(context).pop();
+                                },
+                                child: Text(AppLocalizations.of(context)!.actionContinue)
+                            )
+                          ],
+                        );
+                      }
+                  );
+                } else {
+                  showDialog(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          icon: const Icon(Icons.exit_to_app),
+                          title: Text("In der Moodle App öffnen"),
+                          content: Text("Die Moodle App ist genauso wie lanis-mobile für mobile Endgeräte optimiert. Installiere die App und komme wieder hierher, um direkt zum Login geschickt zu werden."),
+                          actions: [
+                            TextButton(
+                                onPressed: () { launchUrl(Uri.parse("https://apps.apple.com/de/app/moodle/id633359593")); },
+                                child: const Text("App Store")
+                            ),
+                            TextButton(
+                                onPressed: () { launchUrl(Uri.parse("https://play.google.com/store/apps/details?id=com.moodle.moodlemobile")); },
+                                child: const Text("Play Store")
+                            ),
+                            FilledButton(
+                                onPressed: () { Navigator.of(context).pop(); },
+                                child: Text(AppLocalizations.of(context)!.back)
+                            ),
+                          ],
+                        );
+                      });
+                }
+
+                },
+              icon: const Icon(Icons.exit_to_app))
+        ],
       ),
       body: Stack(
         children: [
@@ -118,11 +177,12 @@ class _MoodleWebViewState extends State<MoodleWebView> {
             onLoadStop: (controller, url) {
               pullToRefreshController!.endRefreshing();
               progressIndicator.value = 0;
-
+            },
+            onPageCommitVisible: (controller, uri) {
               // Hack to enable pull to refresh in Moodle.
               controller.evaluateJavascript(
                   source:
-                      "document.documentElement.style.height = document.documentElement.clientHeight + 1 + 'px';");
+                  "document.documentElement.style.height = document.documentElement.clientHeight + 1 + 'px';");
 
               // Hide logout buttons.
               controller.evaluateJavascript(

--- a/app/lib/view/moodle.dart
+++ b/app/lib/view/moodle.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../client/client.dart';
+
+class Moodle extends StatefulWidget {
+  const Moodle({Key? key}) : super(key: key);
+
+  @override
+  _MoodleState createState() => _MoodleState();
+}
+
+class _MoodleState extends State<Moodle> {
+  InAppWebViewController? webViewController;
+
+  @override
+  void initState() {
+    super.initState();
+
+    String sessionToken = "";
+    client.jar.loadForRequest(Uri.parse("https://start.schulportal.hessen.de")).then((cookies) {
+      sessionToken = cookies[1].value;
+    });
+
+    CookieManager cookieManager = CookieManager.instance();
+    cookieManager.deleteAllCookies();
+
+    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "SPH-Session", value: client.singleSignOnToken!, isSecure: true, domain: ".hessen.de");
+    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "sid", value: sessionToken, isSecure: true, domain: ".hessen.de");
+    cookieManager.setCookie(url: WebUri("https://schulportal.hessen.de"), name: "i", value: "6091", isSecure: true, domain: ".hessen.de");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: InAppWebView(
+        initialSettings: InAppWebViewSettings(),
+        initialUrlRequest:
+          URLRequest(url: WebUri("https://mo${client.schoolID}.schulportal.hessen.de")),
+        onWebViewCreated: (controller) {
+          webViewController = controller;
+        },
+        shouldOverrideUrlLoading: (controller, navigationAction) async {
+          final WebUri uri = navigationAction.request.url!;
+
+          if (!uri.rawValue.contains(".schulportal.hessen.de")) {
+            await launchUrl(uri);
+
+            return NavigationActionPolicy.CANCEL;
+          }
+
+          return NavigationActionPolicy.ALLOW;
+        },
+      )
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -20,7 +20,10 @@ environment:
   sdk: '>=3.1.3 <4.0.0'
 
 dependencies:
-  http_proxy: ^1.2.2
+  http_proxy:
+    git:
+      url: https://github.com/Rajala1404/http_proxy.git
+      ref: master
   flutter:
     sdk: flutter
   dio_cookie_manager: ^3.1.0+1
@@ -77,7 +80,7 @@ dependencies:
   flutter_quill: ^9.1.1
   quill_html_converter: ^9.3.2
   flutter_tagging_plus: ^4.0.2
-  flutter_inappwebview: ^6.0.0
+  webview_inapp: ^1.0.3
 
 # flutter_tagging_plus is old and isn't being updated since a long time.
 dependency_overrides:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -77,6 +77,7 @@ dependencies:
   flutter_quill: ^9.1.1
   quill_html_converter: ^9.3.2
   flutter_tagging_plus: ^4.0.2
+  flutter_inappwebview: ^6.0.0
 
 # flutter_tagging_plus is old and isn't being updated since a long time.
 dependency_overrides:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -20,10 +20,7 @@ environment:
   sdk: '>=3.1.3 <4.0.0'
 
 dependencies:
-  http_proxy:
-    git:
-      url: https://github.com/Rajala1404/http_proxy.git
-      ref: master
+  http_proxy: ^1.2.2
   flutter:
     sdk: flutter
   dio_cookie_manager: ^3.1.0+1


### PR DESCRIPTION
Adding a WebView for Moodle (aka a minimal restricted browser?) instead of redirecting to the login website.

We need to use the `flutter_inappwebview` package because Lanis is buggy with the official WebView package and we have more options. 

iOS also shouldn't be a hassle, there are more infos in the [docs](https://inappwebview.dev/docs/intro#setup-ios). (normally it should work without editing configs)

Issues:
- ~Currently doesn't use Material 3 Components, instead I get M2 components although I specified M3.~ Uses a mix of M2 and M3, sometimes weird colour choices but it isn't an issue.
- Need to switch `flutter_inappwebview` with `webview_inapp` temporarily because it doesn't build in release mode.

Todos:
- [x] Use Material Compontents for dialogs, checkboxes, yada yada... because the default components come straight out of 2011 with the old Holo theme (iOS shouldn't have this problem)
- [x] ~More sophisticated URL launching?~ enough
- [x] Prevent logout because it will also destroy the session of the App. (probably need to use JS injection)
- [x] Back, forward and refresh button
- [x] Loading indicators
- [x] ~[Login redirect](https://moodledev.io/general/app/development/link-handling/deep-linking) to the official Moodle app ([Github](https://github.com/moodlehq/moodleapp), [Play Store](https://play.google.com/store/apps/details?id=com.moodle.moodlemobile))~
   - ~for iOS the URL scheme `moodlemobile` must be allowed, more info [here](https://pub.dev/packages/url_launcher#configuration)~