### PR TITLE
calendar: add search and data class + cleanup

### DIFF
--- a/app/lib/client/client_submodules/calendar.dart
+++ b/app/lib/client/client_submodules/calendar.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
+import 'package:intl/intl.dart';
+import '../../shared/types/calendar_event.dart';
 
 import 'package:dio/dio.dart';
 import 'package:sph_plan/client/client.dart';
@@ -16,31 +18,43 @@ class CalendarParser {
     dio = dioClient;
   }
 
-  Future<dynamic> getCalendar(String startDate, String endDate) async {
+  Future<List<CalendarEvent>> getCalendar(
+      {required DateTime startDate,
+      required DateTime endDate,
+      String searchQuery = ''}) async {
     if (!client.doesSupportFeature(SPHAppEnum.kalender)) {
       throw NotSupportedException();
     }
 
+    final formatter = DateFormat('yyyy-MM-dd');
+
     try {
-      final response = await dio.post(
-          "https://start.schulportal.hessen.de/kalender.php",
-          queryParameters: {
-            "f": "getEvents",
-            "start": startDate,
-            "end": endDate
-          },
-          data: 'f=getEvents&start=$startDate&end=$endDate',
-          options: Options(
-            headers: {
-              "Accept": "*/*",
-              "Content-Type":
-                  "application/x-www-form-urlencoded; charset=UTF-8",
-              "Sec-Fetch-Dest": "empty",
-              "Sec-Fetch-Mode": "cors",
-              "Sec-Fetch-Site": "same-origin",
-            },
-          ));
-      return jsonDecode(response.toString());
+      final response =
+          await dio.post("https://start.schulportal.hessen.de/kalender.php",
+              queryParameters: {
+                "f": "getEvents",
+                "s": searchQuery,
+                "start": formatter.format(startDate),
+                "end": formatter.format(endDate),
+              },
+              data: 'f=getEvents&start=$startDate&end=$endDate',
+              options: Options(
+                headers: {
+                  "Accept": "*/*",
+                  "Content-Type":
+                      "application/x-www-form-urlencoded; charset=UTF-8",
+                  "Sec-Fetch-Dest": "empty",
+                  "Sec-Fetch-Mode": "cors",
+                  "Sec-Fetch-Site": "same-origin",
+                },
+              ));
+      final data = jsonDecode(response.data);
+      List<CalendarEvent> finalData = [];
+      for (int i = 0; i < (data as List<dynamic>).length; i++) {
+        finalData.add(CalendarEvent.fromLanisJson(data[i]));
+      }
+
+      return finalData;
     } on SocketException {
       throw NetworkException();
     } catch (e) {

--- a/app/lib/client/client_submodules/calendar.dart
+++ b/app/lib/client/client_submodules/calendar.dart
@@ -37,7 +37,7 @@ class CalendarParser {
                 "start": formatter.format(startDate),
                 "end": formatter.format(endDate),
               },
-              data: 'f=getEvents&start=$startDate&end=$endDate',
+              data: 'f=getEvents&start=$startDate&end=$endDate&s=$searchQuery',
               options: Options(
                 headers: {
                   "Accept": "*/*",
@@ -62,7 +62,7 @@ class CalendarParser {
     }
   }
 
-  Future<dynamic> getEvent(String id) async {
+  Future<Map<String, dynamic>?> getEvent(String id) async {
     if (!(await connectionChecker.connected)) {
       throw NoConnectionException();
     }
@@ -84,7 +84,10 @@ class CalendarParser {
                   "Sec-Fetch-Site": "same-origin",
                 },
               ));
-      return jsonDecode(response.toString());
+      final data = jsonDecode(response.toString());
+      if (data['id'] == '' || data['id'] == null) return null;
+
+      return data;
     } on SocketException {
       throw NetworkException();
     } catch (e) {

--- a/app/lib/client/fetcher.dart
+++ b/app/lib/client/fetcher.dart
@@ -120,6 +120,7 @@ class InvisibleConversationsFetcher extends Fetcher<dynamic> {
 
 class CalendarFetcher extends Fetcher<List<CalendarEvent>> {
   CalendarFetcher(super.validCacheDuration, {super.storageKey});
+  String searchQuery = "";
 
   @override
   Future<List<CalendarEvent>> _get() {
@@ -128,7 +129,7 @@ class CalendarFetcher extends Fetcher<List<CalendarEvent>> {
     DateTime oneYearLater = currentDate.add(const Duration(days: 365));
 
     return client.calendar
-        .getCalendar(startDate: sixMonthsAgo, endDate: oneYearLater);
+        .getCalendar(startDate: sixMonthsAgo, endDate: oneYearLater, searchQuery: searchQuery);
   }
 }
 

--- a/app/lib/client/fetcher.dart
+++ b/app/lib/client/fetcher.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'package:intl/intl.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:sph_plan/client/client_submodules/substitutions.dart';
 import 'package:sph_plan/client/storage.dart';
@@ -9,6 +8,7 @@ import 'package:sph_plan/shared/exceptions/client_status_exceptions.dart';
 
 import '../shared/types/lesson.dart';
 import '../shared/types/timetable.dart';
+import '../shared/types/calendar_event.dart';
 import 'client.dart';
 import 'connection_checker.dart';
 
@@ -45,7 +45,8 @@ abstract class Fetcher<T> {
     }
   }
 
-  void _addResponse(final FetcherResponse<T> data) => _controller.sink.add(data);
+  void _addResponse(final FetcherResponse<T> data) =>
+      _controller.sink.add(data);
 
   Future<void> fetchData({forceRefresh = false, secondTry = false}) async {
     if (!(await connectionChecker.connected)) {
@@ -117,19 +118,17 @@ class InvisibleConversationsFetcher extends Fetcher<dynamic> {
   }
 }
 
-class CalendarFetcher extends Fetcher<dynamic> {
+class CalendarFetcher extends Fetcher<List<CalendarEvent>> {
   CalendarFetcher(super.validCacheDuration, {super.storageKey});
 
   @override
-  Future<dynamic> _get() {
+  Future<List<CalendarEvent>> _get() {
     DateTime currentDate = DateTime.now();
     DateTime sixMonthsAgo = currentDate.subtract(const Duration(days: 180));
     DateTime oneYearLater = currentDate.add(const Duration(days: 365));
 
-    final formatter = DateFormat('yyyy-MM-dd');
-
-    return client.calendar.getCalendar(
-        formatter.format(sixMonthsAgo), formatter.format(oneYearLater));
+    return client.calendar
+        .getCalendar(startDate: sixMonthsAgo, endDate: oneYearLater);
   }
 }
 
@@ -152,7 +151,8 @@ class GlobalFetcher {
 
   GlobalFetcher() {
     if (client.doesSupportFeature(SPHAppEnum.vertretungsplan)) {
-      substitutionsFetcher = SubstitutionsFetcher(const Duration(minutes: 5), storageKey: StorageKey.lastSubstitutionData);
+      substitutionsFetcher = SubstitutionsFetcher(const Duration(minutes: 5),
+          storageKey: StorageKey.lastSubstitutionData);
     }
     if (client.doesSupportFeature(SPHAppEnum.meinUnterricht)) {
       meinUnterrichtFetcher =
@@ -168,7 +168,8 @@ class GlobalFetcher {
       calendarFetcher = CalendarFetcher(null);
     }
     if (client.doesSupportFeature(SPHAppEnum.stundenplan)) {
-      timeTableFetcher = TimeTableFetcher(null, storageKey: StorageKey.lastTimetableData);
+      timeTableFetcher =
+          TimeTableFetcher(null, storageKey: StorageKey.lastTimetableData);
     }
   }
 }

--- a/app/lib/shared/keyboard_observer.dart
+++ b/app/lib/shared/keyboard_observer.dart
@@ -21,6 +21,7 @@ class KeyboardObserver extends ValueNotifier<KeyboardStatus> with WidgetsBinding
     }
   }
 
+  /// Unfocus a text node (Removes the cursor).
   void addDefaultCallback() {
     addListener(() {
       if (value == KeyboardStatus.closed) {

--- a/app/lib/shared/keyboard_observer.dart
+++ b/app/lib/shared/keyboard_observer.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+
+class KeyboardObserver extends ValueNotifier<KeyboardStatus> with WidgetsBindingObserver {
+  KeyboardObserver({
+    KeyboardStatus value = KeyboardStatus.unknown,
+  }) : super(KeyboardStatus.unknown);
+
+  bool _disposed = false;
+
+  void update() {
+    if (_disposed) {
+      return;
+    }
+
+    final view = WidgetsBinding.instance.platformDispatcher.views.first;
+
+    if (view.viewInsets.bottom > 0.0) {
+      value = KeyboardStatus.opened;
+    } else {
+      value = KeyboardStatus.closed;
+    }
+  }
+
+  void addDefaultCallback() {
+    addListener(() {
+      if (value == KeyboardStatus.closed) {
+        FocusManager.instance.primaryFocus?.unfocus();
+      }
+    });
+  }
+
+  @override
+  void didChangeMetrics() {
+    super.didChangeMetrics();
+
+    update();
+  }
+
+  @override
+  void addListener(VoidCallback listener) {
+    if (!hasListeners) {
+      WidgetsBinding.instance.addObserver(this);
+    }
+    if (value == KeyboardStatus.unknown) {
+      update();
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    super.removeListener(listener);
+    if (!_disposed && !hasListeners) {
+      WidgetsBinding.instance.removeObserver(this);
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _disposed = true;
+    super.dispose();
+  }
+}
+
+enum KeyboardStatus {
+  closed,
+  opened,
+  unknown,
+}

--- a/app/lib/shared/types/calendar_event.dart
+++ b/app/lib/shared/types/calendar_event.dart
@@ -7,15 +7,15 @@ class CalendarEvent {
   dynamic lerngruppe;
   bool secret;
   String id;
-  String schoolID;
-  DateTime lastModified;
+  String? schoolID;
+  DateTime? lastModified;
   bool isNew;
   bool public;
   String? place;
   bool private;
   String? responsibleID;
   bool allDay;
-  String category;
+  int? category;
   String description;
   String title;
 
@@ -26,15 +26,15 @@ class CalendarEvent {
     this.lerngruppe,
     required this.secret,
     required this.id,
-    required this.schoolID,
-    required this.lastModified,
+    this.schoolID,
+    this.lastModified,
     required this.isNew,
     required this.public,
     this.place,
     required this.private,
     this.responsibleID,
     required this.allDay,
-    required this.category,
+    this.category,
     required this.description,
     required this.title,
   });
@@ -43,24 +43,25 @@ class CalendarEvent {
   factory CalendarEvent.fromLanisJson(Map<String, dynamic> json) {
     final formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
 
-    return CalendarEvent(
+    final data = CalendarEvent(
       startTime: formatter.parse(json['Anfang']),
       endTime: formatter.parse(json['Ende']),
-      fremdUID: json['FremdUID']??null,
+      fremdUID: json['FremdUID'],
       lerngruppe: json['Lerngruppe']??null,
       secret: json['Geheim'] != 'nein',
       id: json['Id'],
       schoolID: json['Institution'],
-      lastModified: formatter.parse(json['LetzteAenderung']),
+      lastModified: json['LetzteAenderung'] != null ? formatter.parse(json['LetzteAenderung']) : null,
       isNew: json['Neu'] != 'nein',
       public: json['Oeffentlich'] != 'nein',
-      place: json['Ort'] ?? '',
+      place: json['Ort'],
       private: json['Privat'] != 'nein',
-      responsibleID: json['Verantwortlich']??null,
-      allDay: json['allDay'] ?? true,
-      category: json['category'] ?? '0',
+      responsibleID: json['Verantwortlich'],
+      allDay: json['allDay'] ?? false,
+      category: int.tryParse('${json['category']}'),
       description: json['description'] ?? '',
       title: json['title'] ?? '',
     );
+    return data;
   }
 }

--- a/app/lib/shared/types/calendar_event.dart
+++ b/app/lib/shared/types/calendar_event.dart
@@ -1,0 +1,66 @@
+import 'package:intl/intl.dart';
+
+class CalendarEvent {
+  DateTime startTime;
+  DateTime endTime;
+  dynamic fremdUID;
+  dynamic lerngruppe;
+  bool secret;
+  String id;
+  String schoolID;
+  DateTime lastModified;
+  bool isNew;
+  bool public;
+  String? place;
+  bool private;
+  String? responsibleID;
+  bool allDay;
+  String category;
+  String description;
+  String title;
+
+  CalendarEvent({
+    required this.startTime,
+    required this.endTime,
+    this.fremdUID,
+    this.lerngruppe,
+    required this.secret,
+    required this.id,
+    required this.schoolID,
+    required this.lastModified,
+    required this.isNew,
+    required this.public,
+    this.place,
+    required this.private,
+    this.responsibleID,
+    required this.allDay,
+    required this.category,
+    required this.description,
+    required this.title,
+  });
+
+  ///Parses the response of the AJAX SPH events and returns a CalendarEvent object
+  factory CalendarEvent.fromLanisJson(Map<String, dynamic> json) {
+    final formatter = DateFormat('yyyy-MM-dd HH:mm:ss');
+
+    return CalendarEvent(
+      startTime: formatter.parse(json['Anfang']),
+      endTime: formatter.parse(json['Ende']),
+      fremdUID: json['FremdUID']??null,
+      lerngruppe: json['Lerngruppe']??null,
+      secret: json['Geheim'] != 'nein',
+      id: json['Id'],
+      schoolID: json['Institution'],
+      lastModified: formatter.parse(json['LetzteAenderung']),
+      isNew: json['Neu'] != 'nein',
+      public: json['Oeffentlich'] != 'nein',
+      place: json['Ort'] ?? '',
+      private: json['Privat'] != 'nein',
+      responsibleID: json['Verantwortlich']??null,
+      allDay: json['allDay'] ?? true,
+      category: json['category'] ?? '0',
+      description: json['description'] ?? '',
+      title: json['title'] ?? '',
+    );
+  }
+}

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -55,8 +55,23 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
       }
     }
 
-    // Sort by distance to current date
-    searchResults.sort((a, b) => a.startTime.difference(DateTime.now()).abs().compareTo(b.startTime.difference(DateTime.now()).abs()));
+    // Sort by distance to today
+    searchResults.sort((a, b) {
+      int distanceA = a.startTime.differenceInDays(DateTime.now());
+      int distanceB = b.startTime.differenceInDays(DateTime.now());
+      return distanceA.compareTo(distanceB);
+    });
+
+    // move elements of the past to the end
+    searchResults.sort((a, b) {
+      if (a.startTime.isBefore(DateTime.now()) && b.startTime.isAfter(DateTime.now())) {
+        return 1;
+      } else if (a.startTime.isAfter(DateTime.now()) && b.startTime.isBefore(DateTime.now())) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
 
     return searchResults;
   }
@@ -362,6 +377,7 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                 return results.map((event) => ListTile(
                   title: Text(event.title),
                   subtitle: Text('${event.startTime.format("E d MMM y", "de_DE")} - ${event.endTime.format("E d MMM y", "de_DE")}'),
+                  leading: event.endTime.isBefore(DateTime.now()) ? const Icon(Icons.done) : const Icon(Icons.event),
                   onTap: () {
                     setState(() {
                       _selectedDay = event.startTime;

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -40,6 +40,12 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
   void initState() {
     super.initState();
 
+    searchController.addListener(() {
+      if (!searchController.isOpen) {
+        FocusManager.instance.primaryFocus?.unfocus();
+      }
+    });
+
     _selectedDay = _focusedDay;
     _selectedEvents = ValueNotifier(_getEventsForDay(_selectedDay!));
 
@@ -373,7 +379,7 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
             ],
             onSubmitted: (_) {
               FocusScope.of(context).requestFocus(FocusNode());
-              searchController.closeView(null);
+              //searchController.closeView(null);
             },
             suggestionsBuilder: (context, _searchController) {
                 final results = fuzzySearchEventList(_searchController.text);

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -371,6 +371,10 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                 },
               ),
             ],
+            onSubmitted: (_) {
+              FocusScope.of(context).requestFocus(FocusNode());
+              searchController.closeView(null);
+            },
             suggestionsBuilder: (context, _searchController) {
                 final results = fuzzySearchEventList(_searchController.text);
 
@@ -389,8 +393,8 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                     openEventBottomSheet(event);
                   },
                 ),
-                ).toList();
-              },
+              ).toList();
+            },
           ),
         ),
         Expanded(

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -170,46 +170,23 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
       });
     }
 
-    return SizedBox(
-      width: double.infinity,
-      child: Padding(
-        padding: const EdgeInsets.only(left: 20.0, right: 20.0, bottom: 20.0),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            // Title
-            Padding(
-              padding: const EdgeInsets.only(bottom: 8.0),
-              child: Text(
-                calendarData.title,
-                style: Theme.of(context).textTheme.titleLarge,
-              ),
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 20.0),
+      child: ListView(
+        shrinkWrap: true,
+        children: [
+          // Title
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8.0),
+            child: Text(
+              calendarData.title,
+              style: Theme.of(context).textTheme.titleLarge,
             ),
-            // Responsible (Teacher, Admin, ...)
-            if (doesEntryExist(singleEventData["properties"]) &&
-                doesEntryExist(
-                    singleEventData["properties"]["verantwortlich"])) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4.0),
-                child: Row(
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(right: 8.0),
-                      child: Icon(
-                        Icons.person,
-                        size: iconSize,
-                      ),
-                    ),
-                    Text(
-                      singleEventData["properties"]["verantwortlich"],
-                      style: Theme.of(context).textTheme.labelLarge,
-                    )
-                  ],
-                ),
-              )
-            ],
-            // Time
+          ),
+          // Responsible (Teacher, Admin, ...)
+          if (doesEntryExist(singleEventData["properties"]) &&
+              doesEntryExist(
+                  singleEventData["properties"]["verantwortlich"])) ...[
             Padding(
               padding: const EdgeInsets.only(bottom: 4.0),
               child: Row(
@@ -217,101 +194,121 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                   const Padding(
                     padding: EdgeInsets.only(right: 8.0),
                     child: Icon(
-                      Icons.access_time_filled,
+                      Icons.person,
+                      size: iconSize,
+                    ),
+                  ),
+                  Text(
+                    singleEventData["properties"]["verantwortlich"],
+                    style: Theme.of(context).textTheme.labelLarge,
+                  )
+                ],
+              ),
+            )
+          ],
+          // Time
+          Padding(
+            padding: const EdgeInsets.only(bottom: 4.0),
+            child: Row(
+              children: [
+                const Padding(
+                  padding: EdgeInsets.only(right: 8.0),
+                  child: Icon(
+                    Icons.access_time_filled,
+                    size: iconSize,
+                  ),
+                ),
+                Flexible(
+                  child: Text(
+                    date,
+                    style: Theme.of(context).textTheme.labelLarge,
+                  ),
+                )
+              ],
+            ),
+          ),
+          // Place
+          if (doesEntryExist(calendarData.place)) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(right: 8.0),
+                    child: Icon(
+                      Icons.place,
+                      size: iconSize,
+                    ),
+                  ),
+                  Text(calendarData.place!,
+                      style: Theme.of(context).textTheme.labelLarge)
+                ],
+              ),
+            ),
+          ],
+          // Target group
+          if (doesEntryExist(singleEventData["properties"]) &&
+              doesEntryExist(
+                  singleEventData["properties"]["zielgruppen"])) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(right: 8.0),
+                    child: Icon(
+                      Icons.group,
                       size: iconSize,
                     ),
                   ),
                   Flexible(
-                    child: Text(
-                      date,
-                      style: Theme.of(context).textTheme.labelLarge,
-                    ),
+                    child: Text(targetGroup,
+                        style: Theme.of(context).textTheme.labelLarge),
                   )
                 ],
               ),
             ),
-            // Place
-            if (doesEntryExist(calendarData.place)) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4.0),
-                child: Row(
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(right: 8.0),
-                      child: Icon(
-                        Icons.place,
-                        size: iconSize,
-                      ),
-                    ),
-                    Text(calendarData.place!,
-                        style: Theme.of(context).textTheme.labelLarge)
-                  ],
-                ),
-              ),
-            ],
-            // Target group
-            if (doesEntryExist(singleEventData["properties"]) &&
-                doesEntryExist(
-                    singleEventData["properties"]["zielgruppen"])) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4.0),
-                child: Row(
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(right: 8.0),
-                      child: Icon(
-                        Icons.group,
-                        size: iconSize,
-                      ),
-                    ),
-                    Flexible(
-                      child: Text(targetGroup,
-                          style: Theme.of(context).textTheme.labelLarge),
-                    )
-                  ],
-                ),
-              ),
-            ],
-            if (doesEntryExist(calendarData.lerngruppe)) ...[
-              Padding(
-                padding: const EdgeInsets.only(bottom: 4.0),
-                child: Row(
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(right: 8.0),
-                      child: Icon(
-                        Icons.school,
-                        size: iconSize,
-                      ),
-                    ),
-                    Flexible(
-                      child: Text(calendarData.lerngruppe["Name"],
-                          style: Theme.of(context).textTheme.labelLarge),
-                    )
-                  ],
-                ),
-              ),
-            ],
-            if (doesEntryExist(calendarData.description)) ...[
-              Padding(
-                padding: const EdgeInsets.only(top: 8.0),
-                child: Linkify(
-                  onOpen: (link) async {
-                    if (!await launchUrl(Uri.parse(link.url))) {
-                      logger.w("${link.url} konnte nicht geöffnet werden.");
-                    }
-                  },
-                  text: calendarData.description.replaceAll("<br />", "\n"),
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  linkStyle: Theme.of(context)
-                      .textTheme
-                      .bodyMedium!
-                      .copyWith(color: Theme.of(context).colorScheme.primary),
-                ),
-              ),
-            ],
           ],
-        ),
+          if (doesEntryExist(calendarData.lerngruppe)) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 4.0),
+              child: Row(
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(right: 8.0),
+                    child: Icon(
+                      Icons.school,
+                      size: iconSize,
+                    ),
+                  ),
+                  Flexible(
+                    child: Text(calendarData.lerngruppe["Name"],
+                        style: Theme.of(context).textTheme.labelLarge),
+                  )
+                ],
+              ),
+            ),
+          ],
+          if (doesEntryExist(calendarData.description)) ...[
+            Padding(
+              padding: const EdgeInsets.only(top: 8.0),
+              child: Linkify(
+                onOpen: (link) async {
+                  if (!await launchUrl(Uri.parse(link.url))) {
+                    logger.w("${link.url} konnte nicht geöffnet werden.");
+                  }
+                },
+                text: calendarData.description.replaceAll("<br />", "\n"),
+                style: Theme.of(context).textTheme.bodyLarge,
+                linkStyle: Theme.of(context)
+                    .textTheme
+                    .bodyMedium!
+                    .copyWith(color: Theme.of(context).colorScheme.primary),
+              ),
+            ),
+          ],
+          SizedBox(height: 50.0,)
+        ],
       ),
     );
   }
@@ -322,6 +319,8 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
       if (singleEvent == null) return;
       await showModalBottomSheet(
           context: context,
+          isScrollControlled: true,
+          useSafeArea: true,
           showDragHandle: true,
           builder: (context) {
             return eventBottomSheet(calendarData, singleEvent);
@@ -357,6 +356,10 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
             onFocusChange: (hasFocus) {
               if (hasFocus == true && noTrigger == false) {
                 FocusManager.instance.primaryFocus?.consumeKeyboardToken();
+
+                if (keyboardObserver.value == KeyboardStatus.closed) {
+                  FocusManager.instance.primaryFocus?.unfocus();
+                }
               }
             },
             child: SearchAnchor.bar(

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -53,31 +53,28 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
   }
 
   List<CalendarEvent> fuzzySearchEventList(String query) {
-    List<CalendarEvent> searchResults = [];
+    List<CalendarEvent> searchResultsBeforeToday = [];
+    List<CalendarEvent> searchResultsAfterToday = [];
+
     for (var event in eventList) {
       String searchString = '${event.title} ${event.description} ${event.place??''} ${event.startTime.year}'.toLowerCase();
       if (searchString.contains(query.toLowerCase())) {
-        searchResults.add(event);
+        if (event.endTime.isBefore(DateTime.now())) {
+          searchResultsBeforeToday.add(event);
+        } else {
+          searchResultsAfterToday.add(event);
+        }
       }
     }
 
-    // Sort by distance to today
-    searchResults.sort((a, b) {
-      int distanceA = a.startTime.differenceInDays(DateTime.now());
-      int distanceB = b.startTime.differenceInDays(DateTime.now());
-      return distanceA.compareTo(distanceB);
-    });
+    // Sort the search results by date
+    searchResultsBeforeToday.sort((a, b) => b.startTime.compareTo(a.startTime));
+    searchResultsAfterToday.sort((a, b) => a.startTime.compareTo(b.startTime));
 
-    // move elements of the past to the end
-    searchResults.sort((a, b) {
-      if (a.startTime.isBefore(DateTime.now()) && b.startTime.isAfter(DateTime.now())) {
-        return 1;
-      } else if (a.startTime.isAfter(DateTime.now()) && b.startTime.isBefore(DateTime.now())) {
-        return -1;
-      } else {
-        return 0;
-      }
-    });
+    List<CalendarEvent> searchResults = [];
+    searchResults.addAll(searchResultsAfterToday);
+    searchResults.addAll(searchResultsBeforeToday);
+
 
     return searchResults;
   }

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -49,10 +49,15 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
   List<CalendarEvent> fuzzySearchEventList(String query) {
     List<CalendarEvent> searchResults = [];
     for (var event in eventList) {
-      if (event.title.toLowerCase().contains(query.toLowerCase())) {
+      String searchString = '${event.title} ${event.description} ${event.place??''} ${event.startTime.year}'.toLowerCase();
+      if (searchString.contains(query.toLowerCase())) {
         searchResults.add(event);
       }
     }
+
+    // Sort by distance to current date
+    searchResults.sort((a, b) => a.startTime.difference(DateTime.now()).abs().compareTo(b.startTime.difference(DateTime.now()).abs()));
+
     return searchResults;
   }
 

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -527,23 +527,3 @@ List<DateTime> daysInRange(DateTime first, DateTime last) {
     (index) => DateTime.utc(first.year, first.month, first.day + index),
   );
 }
-
-DateTime parseDateString(String dateString) {
-  // Parse the date string
-  List<String> dateTimeParts = dateString.split(' ');
-  List<String> dateParts = dateTimeParts[0].split('-');
-  List<String> timeParts = dateTimeParts[1].split(':');
-
-  // Extract year, month, day, hour, minute, and second
-  int year = int.parse(dateParts[0]);
-  int month = int.parse(dateParts[1]);
-  int day = int.parse(dateParts[2]);
-  int hour = int.parse(timeParts[0]);
-  int minute = int.parse(timeParts[1]);
-  int second = int.parse(timeParts[2]);
-
-  // Create a DateTime object
-  DateTime dateTime = DateTime(year, month, day, hour, minute, second);
-
-  return dateTime;
-}

--- a/app/lib/view/calendar/calendar.dart
+++ b/app/lib/view/calendar/calendar.dart
@@ -356,7 +356,7 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
           child: Focus(
             onFocusChange: (hasFocus) {
               if (hasFocus == true && noTrigger == false) {
-                FocusManager.instance.primaryFocus?.unfocus();
+                FocusManager.instance.primaryFocus?.consumeKeyboardToken();
               }
             },
             child: SearchAnchor.bar(
@@ -509,7 +509,9 @@ class _CalendarAnsichtState extends State<CalendarAnsicht> {
                                         shape: RoundedRectangleBorder(
                                           borderRadius: BorderRadius.circular(12),
                                         ),
-                                        onTap: () => openEventBottomSheet(value[index]),
+                                        onTap: () async {
+                                          await openEventBottomSheet(value[index]);
+                                        },
                                       ),
                                     ),
                                   );

--- a/app/lib/view/data_storage/root_view.dart
+++ b/app/lib/view/data_storage/root_view.dart
@@ -115,13 +115,13 @@ class _AsyncSearchAnchorState extends State<AsyncSearchAnchor> {
     }, suggestionsBuilder:
             (BuildContext context, SearchController controller) async {
       _searchingWithQuery = controller.text;
-      var options = await client.dataStorage.searchFiles(_searchingWithQuery!);
+      var options = await client.dataStorage.searchFiles(_searchingWithQuery??'');
 
       if (_searchingWithQuery != controller.text) {
         return _lastOptions;
       }
 
-      _lastOptions = List<Widget>.generate(options.length, (int index) {
+      _lastOptions = List<Widget>.generate(options?.length??0, (int index) {
         final Map item = options[index];
         return SearchFileListTile(
             context: context,

--- a/app/lib/view/timetable/view.dart
+++ b/app/lib/view/timetable/view.dart
@@ -67,8 +67,14 @@ class _StaticTimetableViewState extends State<StaticTimetableView> {
       ));
     }
     return SfCalendar(
-      view: CalendarView.day,
-      headerHeight: 0,
+      view: DateTime.now().weekday == DateTime.saturday || DateTime.now().weekday == DateTime.sunday
+          ? CalendarView.week
+          : CalendarView.workWeek,
+      allowedViews: [
+        CalendarView.day,
+        CalendarView.week,
+        CalendarView.workWeek,
+      ],
       timeSlotViewSettings: const TimeSlotViewSettings(
         timeFormat: "HH:mm",
       ),
@@ -198,10 +204,20 @@ class TimeTableDataSource extends CalendarDataSource {
 
         final Color entryColor = generateColor(lesson.name!, Colors.blue);
 
+        //1 week before
+        events.add(Appointment(
+            startTime: startTime.subtract(const Duration(days: 7)),
+            endTime: endTime.subtract(const Duration(days: 7)),
+            subject: "${lesson.name!} ${lesson.lehrer} ${lesson.raum??""}",
+            location: lesson.raum,
+            notes: lesson.badge,
+            color: entryColor,
+            id: "${dayIndex - 1}-$lessonIndex-1"));
+
         events.add(Appointment(
             startTime: startTime,
             endTime: endTime,
-            subject: "${lesson.name!} ${lesson.lehrer}",
+            subject: "${lesson.name!} ${lesson.lehrer} ${lesson.raum??""}",
             location: lesson.raum,
             notes: lesson.badge,
             color: entryColor,

--- a/app/lib/view/timetable/view.dart
+++ b/app/lib/view/timetable/view.dart
@@ -178,22 +178,11 @@ class _StaticTimetableViewState extends State<StaticTimetableView> {
 class TimeTableDataSource extends CalendarDataSource {
   TimeTableDataSource(List<Day>? data) {
     final now = DateTime.now();
-
+    final lastMonday = now.subtract(Duration(days: now.weekday - 1));
     var events = <Appointment>[];
 
     for (var (dayIndex, day) in data!.indexed) {
-      dayIndex += 1;
-      // Calculate the difference between the current weekday and the dayIndex
-      var diff = dayIndex - now.weekday;
-      // If the dayIndex is less than the current weekday, add 7 to ensure the date is in the future
-      if (diff < 0) {
-        diff += 7;
-      } else if (diff == 0) {
-        diff = 0;
-      }
-
-      // Add the difference to the current date to get the correct date
-      final date = now.add(Duration(days: diff));
+      final date = lastMonday.add(Duration(days: dayIndex));
 
       for (var (lessonIndex, lesson) in day.indexed) {
         // Use the calculated date for the startTime and endTime

--- a/app/lib/view/timetable/view.dart
+++ b/app/lib/view/timetable/view.dart
@@ -227,7 +227,7 @@ class TimeTableDataSource extends CalendarDataSource {
         events.add(Appointment(
             startTime: startTime.add(const Duration(days: 7)),
             endTime: endTime.add(const Duration(days: 7)),
-            subject: lesson.name!,
+            subject: "${lesson.name!} ${lesson.lehrer} ${lesson.raum??""}",
             location: lesson.raum,
             notes: lesson.lehrer,
             color: entryColor,


### PR DESCRIPTION
Implementing on device search for the calendar. (network search is scuffed, only returns specific results)
Also: allowing classic timetable view alongside Day view.