### PR TITLE
Fix appointment popup mismatch by correcting ID generation

### DIFF
--- a/app/lib/view/timetable/view.dart
+++ b/app/lib/view/timetable/view.dart
@@ -43,7 +43,7 @@ class _StaticTimetableViewState extends State<StaticTimetableView> {
       ),
     );
   }
-  
+
   Widget getBody() {
     if (widget.loading) {
       return const Center(
@@ -201,7 +201,7 @@ class TimeTableDataSource extends CalendarDataSource {
             location: lesson.raum,
             notes: lesson.badge,
             color: entryColor,
-            id: "${dayIndex - 1}-$lessonIndex-1"));
+            id: "${dayIndex}-${lessonIndex}-1"));
 
         events.add(Appointment(
             startTime: startTime,
@@ -210,7 +210,7 @@ class TimeTableDataSource extends CalendarDataSource {
             location: lesson.raum,
             notes: lesson.badge,
             color: entryColor,
-            id: "${dayIndex - 1}-$lessonIndex-1"));
+            id: "${dayIndex}-${lessonIndex}-2"));
 
         //1 week later
         events.add(Appointment(
@@ -220,7 +220,7 @@ class TimeTableDataSource extends CalendarDataSource {
             location: lesson.raum,
             notes: lesson.lehrer,
             color: entryColor,
-            id: "${dayIndex - 1}-$lessonIndex-2"));
+            id: "${dayIndex}-${lessonIndex}-3"));
       }
     }
 


### PR DESCRIPTION
This pull request addresses the issue where clicking on an appointment displays a popup for a different appointment. The problem was caused by incorrect ID generation in the TimeTableDataSource class. The ID generation logic has been corrected to ensure each appointment has a unique ID based on the dayIndex and lessonIndex.

Before:
![image](https://github.com/user-attachments/assets/940d28e9-57c3-4328-ba68-5e12cd23ae0d)

After:
![image](https://github.com/user-attachments/assets/599f71b0-407a-438b-87dc-e2500f0fc75f)
