### PR TITLE
make sure dates like "12:00" dont get formatted to "12:0"

### DIFF
--- a/app/lib/view/timetable/view.dart
+++ b/app/lib/view/timetable/view.dart
@@ -122,7 +122,7 @@ class _StaticTimetableViewState extends State<StaticTimetableView> {
                         if (selected.raum != null)
                           modalSheetItem(selected.raum!, Icons.place),
                         modalSheetItem(
-                            "${selected.startTime.hour}:${selected.startTime.minute} - ${selected.endTime.hour}:${selected.endTime.minute} (${selected.duration} ${selected.duration == 1 ? "Stunde" : "Stunden"})",
+                            "${selected.startTime.hour}:${selected.startTime.minute.toString().padLeft(2, '0')} - ${selected.endTime.hour}:${selected.endTime.minute.toString().padLeft(2, '0')} (${selected.duration} ${selected.duration == 1 ? "Stunde" : "Stunden"})",
                             Icons.access_time),
                         if (selected.lehrer != null)
                           modalSheetItem(selected.lehrer!, Icons.person),


### PR DESCRIPTION
If you look at the detailed view of a class in timetable it formats the time of the class to "12:0" if the time is actually "12:00". Not really a real bug, but looks weird.