### PR TITLE
add border to calender event indicators

### DIFF
--- a/app/lib/applets/calendar/calendar_view.dart
+++ b/app/lib/applets/calendar/calendar_view.dart
@@ -512,7 +512,9 @@ class _CalendarViewState extends State<CalendarView> {
                                       decoration: BoxDecoration(
                                           shape: BoxShape.circle,
                                             color: events[index].color,
-                                            border: Border.all(color: Theme.of(context).colorScheme.onSurface, width: 0.7)),
+                                            border: (events[index].color.computeLuminance() - Theme.of(context).colorScheme.surface.computeLuminance()).abs() < 0.02
+                                              ? Border.all(color: Theme.of(context).colorScheme.onSurface, width: 1)
+                                              : null),
                                     ),
                                   );
                                 },

--- a/app/lib/applets/calendar/calendar_view.dart
+++ b/app/lib/applets/calendar/calendar_view.dart
@@ -511,7 +511,8 @@ class _CalendarViewState extends State<CalendarView> {
                                       width: 6,
                                       decoration: BoxDecoration(
                                           shape: BoxShape.circle,
-                                          color: events[index].color),
+                                            color: events[index].color,
+                                            border: Border.all(color: Theme.of(context).colorScheme.onSurface, width: 0.7)),
                                     ),
                                   );
                                 },

--- a/app/lib/applets/calendar/calendar_view.dart
+++ b/app/lib/applets/calendar/calendar_view.dart
@@ -1,18 +1,18 @@
 import 'package:dart_date/dart_date.dart';
 import 'package:flutter/material.dart';
-import 'package:sph_plan/applets/calendar/definition.dart';
-import 'package:sph_plan/widgets/combined_applet_builder.dart';
-import 'package:sph_plan/utils/keyboard_observer.dart';
-import 'package:table_calendar/table_calendar.dart';
-import 'package:flutter_linkify/flutter_linkify.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:sph_plan/applets/calendar/definition.dart';
+import 'package:sph_plan/utils/keyboard_observer.dart';
+import 'package:sph_plan/widgets/combined_applet_builder.dart';
+import 'package:table_calendar/table_calendar.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../core/sph/sph.dart';
 import '../../models/calendar_event.dart';
 import '../../models/client_status_exceptions.dart';
-import '../../widgets/error_view.dart';
 import '../../utils/logger.dart';
+import '../../widgets/error_view.dart';
 
 class CalendarView extends StatefulWidget {
   final Function? openDrawerCb;
@@ -511,9 +511,21 @@ class _CalendarViewState extends State<CalendarView> {
                                       width: 6,
                                       decoration: BoxDecoration(
                                           shape: BoxShape.circle,
-                                            color: events[index].color,
-                                            border: (events[index].color.computeLuminance() - Theme.of(context).colorScheme.surface.computeLuminance()).abs() < 0.02
-                                              ? Border.all(color: Theme.of(context).colorScheme.onSurface, width: 1)
+                                          color: events[index].color,
+                                          border: (events[index]
+                                                              .color
+                                                              .computeLuminance() -
+                                                          Theme.of(context)
+                                                              .colorScheme
+                                                              .surface
+                                                              .computeLuminance())
+                                                      .abs() <
+                                                  0.02
+                                              ? Border.all(
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface,
+                                                  width: 0.75)
                                               : null),
                                     ),
                                   );
@@ -555,43 +567,61 @@ class _CalendarViewState extends State<CalendarView> {
                                           left: 8, right: 8, bottom: 4),
                                       child: Card(
                                         child: InkWell(
-                                          borderRadius: BorderRadius.circular(12),
-                                            onTap: () async {
-                                              await openEventBottomSheet(
-                                                  value[index]);
-                                            },
+                                          borderRadius:
+                                              BorderRadius.circular(12),
+                                          onTap: () async {
+                                            await openEventBottomSheet(
+                                                value[index]);
+                                          },
                                           child: Row(
                                             children: [
                                               Container(
                                                 width: 8,
                                                 height: 40,
                                                 decoration: BoxDecoration(
-                                                  color: value[index].color,
-                                                  borderRadius: BorderRadius.circular(8)
-                                                ),
+                                                    color: value[index].color,
+                                                    borderRadius:
+                                                        BorderRadius.circular(
+                                                            8)),
                                               ),
                                               Expanded(
                                                 child: Padding(
-                                                  padding: const EdgeInsets.all(8),
+                                                  padding:
+                                                      const EdgeInsets.all(8),
                                                   child: Column(
-                                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                                    crossAxisAlignment:
+                                                        CrossAxisAlignment
+                                                            .start,
                                                     children: [
                                                       Text(
                                                         value[index].title,
-                                                        style: Theme.of(context).textTheme.titleMedium,
+                                                        style: Theme.of(context)
+                                                            .textTheme
+                                                            .titleMedium,
                                                       ),
                                                       Text(
                                                         maxLines: 1,
-                                                        overflow: TextOverflow.ellipsis,
-                                                        value[index].category?.name ?? value[index].place ?? value[index].description,
-                                                        style: Theme.of(context).textTheme.bodyMedium,
+                                                        overflow: TextOverflow
+                                                            .ellipsis,
+                                                        value[index]
+                                                                .category
+                                                                ?.name ??
+                                                            value[index]
+                                                                .place ??
+                                                            value[index]
+                                                                .description,
+                                                        style: Theme.of(context)
+                                                            .textTheme
+                                                            .bodyMedium,
                                                       ),
                                                     ],
                                                   ),
                                                 ),
                                               ),
                                               Icon(Icons.arrow_right),
-                                              SizedBox(width: 8,)
+                                              SizedBox(
+                                                width: 8,
+                                              )
                                             ],
                                           ),
                                         ),


### PR DESCRIPTION
About issue #370 

This pull request includes a visual enhancement to the calendar view in the `app/lib/applets/calendar/calendar_view.dart` file. The change adds a border to the event indicators to improve their visibility.

Visual enhancement to calendar view:

* [`app/lib/applets/calendar/calendar_view.dart`](diffhunk://#diff-6d735357f855d2a5e11a8c31df4936de614fc7bf2ee4603fb67741b49ff63f6cL514-R515): Added a border to the event indicators with a color from the theme's color scheme and a width of 0.7.

Border with both other colors and black
![image](https://github.com/user-attachments/assets/aa2ea33f-45f3-4abf-8c81-02f7a75fed95)
![image](https://github.com/user-attachments/assets/e4c9fe72-1004-44ff-a593-06075634cff1)

