### PR TITLE
Prevent classes in substitution tiles from overflowing

### DIFF
--- a/app/lib/applets/substitutions/substitutions_listtile.dart
+++ b/app/lib/applets/substitutions/substitutions_listtile.dart
@@ -40,109 +40,118 @@ class SubstitutionListTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      dense: (doesNoticeExist(substitutionData.vertreter) &&
-          doesNoticeExist(substitutionData.lehrer) &&
-          doesNoticeExist(substitutionData.raum) &&
-          doesNoticeExist(substitutionData.fach) &&
-          doesNoticeExist(substitutionData.hinweis)),
-      title: Padding(
-        padding: const EdgeInsets.only(top: 2),
-        child: (substitutionData.art != null)
-            ? MarqueeWidget(
-                direction: Axis.horizontal,
-                child: Text(
-                  substitutionData.art!,
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              )
-            : null,
-      ),
-      subtitle: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: EdgeInsets.only(
-                top: 0,
-                bottom: (doesNoticeExist(substitutionData.vertreter) &&
-                        doesNoticeExist(substitutionData.lehrer) &&
-                        doesNoticeExist(substitutionData.raum) &&
-                        !doesNoticeExist(substitutionData.fach))
-                    ? 12
-                    : 0),
-            child: Column(
-              children: [
-                getSubstitutionInfo(context, "Vertreter",
-                        substitutionData.vertreter, Icons.person) ??
-                    const SizedBox.shrink(),
-                getSubstitutionInfo(context, "Lehrer", substitutionData.lehrer,
-                        Icons.school) ??
-                    const SizedBox.shrink(),
-                getSubstitutionInfo(
-                        context, "Raum", substitutionData.raum, Icons.room) ??
-                    const SizedBox.shrink(),
-              ],
-            ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final maxClassWidth = constraints.maxWidth * 0.3; // Limit class width to 30% of the tile width
+
+        return ListTile(
+          dense: (doesNoticeExist(substitutionData.vertreter) &&
+              doesNoticeExist(substitutionData.lehrer) &&
+              doesNoticeExist(substitutionData.raum) &&
+              doesNoticeExist(substitutionData.fach) &&
+              doesNoticeExist(substitutionData.hinweis)),
+          title: Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: (substitutionData.art != null)
+                ? MarqueeWidget(
+                    direction: Axis.horizontal,
+                    child: Text(
+                      substitutionData.art!,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  )
+                : null,
           ),
-          if (!doesNoticeExist(substitutionData.hinweis)) ...[
-            Padding(
-              padding: EdgeInsets.only(
-                  right: 30,
-                  left: 30,
-                  top: 2,
-                  bottom: doesNoticeExist(substitutionData.fach) ? 12 : 0),
-              child: Column(
-                children: [
-                  Row(
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: EdgeInsets.only(
+                    top: 0,
+                    bottom: (doesNoticeExist(substitutionData.vertreter) &&
+                            doesNoticeExist(substitutionData.lehrer) &&
+                            doesNoticeExist(substitutionData.raum) &&
+                            !doesNoticeExist(substitutionData.fach))
+                        ? 12
+                        : 0),
+                child: Column(
+                  children: [
+                    getSubstitutionInfo(context, "Vertreter",
+                            substitutionData.vertreter, Icons.person) ??
+                        const SizedBox.shrink(),
+                    getSubstitutionInfo(context, "Lehrer", substitutionData.lehrer,
+                            Icons.school) ??
+                        const SizedBox.shrink(),
+                    getSubstitutionInfo(
+                            context, "Raum", substitutionData.raum, Icons.room) ??
+                        const SizedBox.shrink(),
+                  ],
+                ),
+              ),
+              if (!doesNoticeExist(substitutionData.hinweis)) ...[
+                Padding(
+                  padding: EdgeInsets.only(
+                      right: 30,
+                      left: 30,
+                      top: 2,
+                      bottom: doesNoticeExist(substitutionData.fach) ? 12 : 0),
+                  child: Column(
                     children: [
-                      const Padding(
-                        padding: EdgeInsets.only(right: 8.0),
-                        child: Icon(Icons.info),
+                      Row(
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.only(right: 8.0),
+                            child: Icon(Icons.info),
+                          ),
+                          Flexible(
+                            fit: FlexFit.loose,
+                            child: Text(
+                              substitutionData.hinweis!,
+                              overflow: TextOverflow.visible,
+                              softWrap: true,
+                            ),
+                          ),
+                        ],
                       ),
-                      Flexible(
-                        fit: FlexFit.loose,
-                        child: Text(
-                          substitutionData.hinweis!,
-                          overflow: TextOverflow.visible,
-                          softWrap: true,
-                        ),
-                      ),
+                      const SizedBox(height: 4)
                     ],
                   ),
-                  const SizedBox(height: 4)
+                )
+              ],
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  if (!doesNoticeExist(substitutionData.klasse)) ...[
+                    ConstrainedBox(
+                      constraints: BoxConstraints(maxWidth: maxClassWidth),
+                      child: MarqueeWidget(
+                        direction: Axis.horizontal,
+                        child: Text(
+                          substitutionData.klasse!,
+                          style: Theme.of(context).textTheme.titleMedium,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                    ),
+                  ],
+                  if (!doesNoticeExist(substitutionData.fach)) ...[
+                    Text(
+                      substitutionData.fach!,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ],
+                  if (!doesNoticeExist(substitutionData.stunde)) ...[
+                    Text(
+                      substitutionData.stunde,
+                      style: Theme.of(context).textTheme.titleLarge,
+                    ),
+                  ]
                 ],
               ),
-            )
-          ],
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              if (!doesNoticeExist(substitutionData.klasse)) ...[
-                SizedBox(
-
-                  child: MarqueeWidget(
-                      child: Text(
-                    substitutionData.klasse!,
-                    style: Theme.of(context).textTheme.titleMedium,
-                  )),
-                ),
-              ],
-              if (!doesNoticeExist(substitutionData.fach)) ...[
-                Text(
-                  substitutionData.fach!,
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ],
-              if (!doesNoticeExist(substitutionData.stunde)) ...[
-                Text(
-                  substitutionData.stunde,
-                  style: Theme.of(context).textTheme.titleLarge,
-                ),
-              ]
             ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `SubstitutionListTile` class in `app/lib/applets/substitutions/substitutions_listtile.dart` to improve the layout and ensure better handling of long text.

Improvements to layout and text handling:

* [`app/lib/applets/substitutions/substitutions_listtile.dart`](diffhunk://#diff-a47cfa5e2ee0aeb0f336ddc3792a8d37f9a328780a84b3e1f2a3327cc64bc23bR43-R46): Added a `LayoutBuilder` to limit the class width to 30% of the tile width.
* [`app/lib/applets/substitutions/substitutions_listtile.dart`](diffhunk://#diff-a47cfa5e2ee0aeb0f336ddc3792a8d37f9a328780a84b3e1f2a3327cc64bc23bL121-R134): Replaced `SizedBox` with `ConstrainedBox` to apply the width constraint and added a `MarqueeWidget` to handle horizontal scrolling of long text with ellipsis overflow. [[1]](diffhunk://#diff-a47cfa5e2ee0aeb0f336ddc3792a8d37f9a328780a84b3e1f2a3327cc64bc23bL121-R134) [[2]](diffhunk://#diff-a47cfa5e2ee0aeb0f336ddc3792a8d37f9a328780a84b3e1f2a3327cc64bc23bR154-R155)


![image](https://github.com/user-attachments/assets/bd013015-8652-4c45-b999-ab8af14e984b)

EDIT:
As stated below this is supposed to be more of a short time fix until the update for the substitutions are released.
