### PR TITLE
only log in release mode

### DIFF
--- a/app/lib/core/sph/session.dart
+++ b/app/lib/core/sph/session.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:cookie_jar/cookie_jar.dart';
 import 'package:dio/dio.dart';
 import 'package:dio_cookie_manager/dio_cookie_manager.dart';
+import 'package:flutter/foundation.dart';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -22,7 +23,7 @@ import 'sph.dart';
 class SessionHandler {
   SPH sph;
   String? schoolName;
-  
+
   late Cryptor cryptor = Cryptor();
   late CookieJar jar;
   final dio = Dio();
@@ -105,7 +106,7 @@ class SessionHandler {
 
     travelMenu = await getFastTravelMenu();
     if (!withoutData) {
-      asyncLogRequest();
+      if(!kDebugMode) asyncLogRequest();
       accountDatabase.updateLastLogin(sph.account.localId);
 
       final response = await dio.get(

--- a/app/lib/core/sph/session.dart
+++ b/app/lib/core/sph/session.dart
@@ -106,7 +106,7 @@ class SessionHandler {
 
     travelMenu = await getFastTravelMenu();
     if (!withoutData) {
-      if(!kDebugMode) asyncLogRequest();
+      if(kReleaseMode) asyncLogRequest();
       accountDatabase.updateLastLogin(sph.account.localId);
 
       final response = await dio.get(


### PR DESCRIPTION
Every hot restart triggers a request being logged. Looking at today's logs, you can see a school's count is higher than yesterday's at around 06:00, likely due to hot restarts or  generally development launches.  This skews the stats for the schools we are working on. Not trivial though