### PR TITLE
Fix: Show actual update time for substitutions

### DIFF
--- a/app/lib/applets/substitutions/substitutions_view.dart
+++ b/app/lib/applets/substitutions/substitutions_view.dart
@@ -223,12 +223,13 @@ class _SubstitutionsViewState extends State<SubstitutionsView>
                 slivers: [
                   SliverFillRemaining(
                     child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
+                      mainAxisSize: MainAxisSize.max,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
+                        Spacer(),
                         const Icon(Icons.sentiment_dissatisfied, size: 60),
                         Padding(
-                          padding: const EdgeInsets.all(35),
+                          padding: const EdgeInsets.all(32),
                           child: Text(AppLocalizations.of(context).noEntries,
                               textAlign: TextAlign.center,
                               style: const TextStyle(
@@ -236,6 +237,15 @@ class _SubstitutionsViewState extends State<SubstitutionsView>
                                 fontWeight: FontWeight.bold,
                               )),
                         ),
+                        Spacer(),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
+                          child: Text(
+                            AppLocalizations.of(context)
+                                .substitutionsLastEdit(data.lastUpdated.format('dd.MM.yyyy HH:mm')),
+                            textAlign: TextAlign.center,
+                          ),
+                        )
                       ],
                     ),
                   )

--- a/app/lib/l10n/intl_de.arb
+++ b/app/lib/l10n/intl_de.arb
@@ -61,6 +61,7 @@
   "noFurtherEntries": "Keine weiteren Einträge!",
   "noEntries": "Keine Einträge!",
   "substitutionsEndCardMessage": "Nicht richtig? Überprüfe, ob dein Filter richtig eingestellt ist. Eventuell solltest du dich an die IT-Abteilung deiner Schule wenden.\nLetzte Aktualisierung: {time}",
+  "substitutionsLastEdit": "Letzte Aktualisierung: {time}",
   "substitutionsInformationMessage": "Es liegen Anmerkungen zu diesem Tag vor",
   "logout": "Logout",
   "logoutConfirmation": "Bist du sicher, dass du dich abmelden möchtest?",

--- a/app/lib/l10n/intl_en.arb
+++ b/app/lib/l10n/intl_en.arb
@@ -61,6 +61,7 @@
   "noFurtherEntries": "No further entries!",
   "noEntries": "No Entries!",
   "substitutionsEndCardMessage": "Not correct? Check whether your filter is set correctly. You may need to contact your school's IT department.\nLast edited: {time}",
+  "substitutionsLastEdit": "Last edit: {time}",
   "substitutionsInformationMessage": "There is information available for this day",
   "logout": "Logout",
   "logoutConfirmation": "Do you really want to log out?",

--- a/app/lib/models/substitution.dart
+++ b/app/lib/models/substitution.dart
@@ -210,9 +210,11 @@ class SubstitutionDay {
 /// A data class to store all substitution information available
 class SubstitutionPlan {
   final List<SubstitutionDay> days;
-  DateTime lastUpdated = DateTime.now();
+  DateTime lastUpdated;
 
-  SubstitutionPlan({List<SubstitutionDay>? days}) : days = days ?? [];
+  SubstitutionPlan({List<SubstitutionDay>? days, DateTime? lastUpdated}) 
+      : days = days ?? [],
+        lastUpdated = lastUpdated ?? DateTime.now();
 
   void add(SubstitutionDay substitutionDay) {
     days.add(substitutionDay);


### PR DESCRIPTION
This pull request fixes the issue where the substitution page displays only the current time instead of the edited time from lanis.