### PR TITLE
fix crash introduced by PR

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        tools:replace="android:label"
         android:label="Lanis"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url "${project(':background_fetch').projectDir}/libs" }
     }
     subprojects {
         afterEvaluate { project ->

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   html: ^0.15.4
   flutter_launcher_icons: ^0.14.0
   flutter_local_notifications: ^18.0.1
-  background_fetch: ^1.1.3
+  background_fetch: ^1.3.7
   flutter_background_executor: ^1.0.0
   permission_handler: ^11.0.1
   package_info_plus: ^8.0.0


### PR DESCRIPTION
Fixes android build crash by #385 . Idk, probably we should ditch that plugin anyways, but iOS works, and working things do not get removed ig. But yeah, that fixes the android build thinggy.

And upgraded version. Idk why it was old - like very old. @alessioC42 Hope this does not break iOS, as it is the backgroundfetcher for it