### PR TITLE
Adds build for commits

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches-ignore:
       - main
-    paths:
-      - 'lib/**'
 
 jobs:
   build-android:
@@ -25,12 +23,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-
-      - name: Install jq
-        run: |
-          wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
-          chmod +x ./jq
-          mv jq /usr/local/bin
 
       - name: Add exception
         run: git config --global --add safe.directory /opt/hostedtoolcache/flutter/*
@@ -59,7 +51,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-build
-          path: app-release.apk
+          path: app-debug.apk
 
       - name: Clean up
         if: always()

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,8 +2,8 @@ name: Flutter Build
 
 on:
   workflow_dispatch:
-  push:
-    branches-ignore:
+  pull_request:
+    branches:
       - main
     paths:
       - 'app/lib/**'
@@ -48,12 +48,12 @@ jobs:
 
       - name: Build APK
         working-directory: ./app
-        run: flutter build apk --debug
+        run: flutter build apk --debug --flavor dev
 
       - name: Move APK and AAB files
         working-directory: ./app
         run: |
-          mv build/app/outputs/flutter-apk/app-debug.apk app-debug.apk
+          mv build/app/outputs/flutter-apk/app-dev-debug.apk app-debug.apk
 
       - name: Upload APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Flutter setup
         working-directory: ./app
         run: |
-            dart run build_runner build
+            dart run build_runner build --delete-conflicting-outputs
             dart run intl_utils:generate
 
       - name: Build APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,67 @@
+name: Flutter Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - 'lib/**'
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget curl xz-utils git>=2.0 bash unzip bash zip
+
+      - name: Install Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Install jq
+        run: |
+          wget -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+          chmod +x ./jq
+          mv jq /usr/local/bin
+
+      - name: Add exception
+        run: git config --global --add safe.directory /opt/hostedtoolcache/flutter/*
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      - name: Flutter setup
+        run: |
+            dart run build_runner build
+            dart run intl_utils:generate
+
+      - name: Build APK
+        run: flutter build apk --debug
+
+      - name: Move APK and AAB files
+        run: |
+          mv build/app/outputs/flutter-apk/app-debug.apk app-debug.apk
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-build
+          path: app-release.apk
+
+      - name: Clean up
+        if: always()
+        run: |
+          sudo rm -rf build

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches-ignore:
       - main
+    paths:
+      - 'app/lib/**'
 
 jobs:
   build-android:
@@ -57,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-build
-          path: app-debug.apk
+          path: ./app/app-debug.apk
 
       - name: Clean up
         if: always()

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
+        working-directory: ./app
         run: |
           sudo apt-get update
           sudo apt-get install -y wget curl xz-utils git>=2.0 bash unzip bash zip
@@ -25,6 +26,7 @@ jobs:
           java-version: '17'
 
       - name: Add exception
+        working-directory: ./app
         run: git config --global --add safe.directory /opt/hostedtoolcache/flutter/*
 
       - name: Set up Flutter
@@ -33,17 +35,21 @@ jobs:
           channel: stable
 
       - name: Install Flutter dependencies
+        working-directory: ./app
         run: flutter pub get
 
       - name: Flutter setup
+        working-directory: ./app
         run: |
             dart run build_runner build
             dart run intl_utils:generate
 
       - name: Build APK
+        working-directory: ./app
         run: flutter build apk --debug
 
       - name: Move APK and AAB files
+        working-directory: ./app
         run: |
           mv build/app/outputs/flutter-apk/app-debug.apk app-debug.apk
 

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -77,6 +77,16 @@ android {
         }
     }
 
+    flavorDimensions "default"
+    productFlavors {
+        dev {
+            dimension "default"
+            applicationIdSuffix ".dev"
+            versionNameSuffix ".dev"
+        }
+    }
+
+
 }
 
 flutter {

--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <manifest xmlns:tools="http://schemas.android.com/tools" xmlns:android="http://schemas.android.com/apk/res/android">
     <application
+        tools:replace="android:label"
         android:label="Lanis"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"

--- a/app/android/build.gradle
+++ b/app/android/build.gradle
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url "${project(':background_fetch').projectDir}/libs" }
     }
     subprojects {
         afterEvaluate { project ->

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   html: ^0.15.4
   flutter_launcher_icons: ^0.14.0
   flutter_local_notifications: ^18.0.1
-  background_fetch: ^1.1.3
+  background_fetch: ^1.3.7
   flutter_background_executor: ^1.0.0
   permission_handler: ^11.0.1
   package_info_plus: ^8.0.0


### PR DESCRIPTION
# Why?

To prevent anything from breaking like #385 did accidentally.

There is little to no maintenance needed once this is set up (which it now is).

We should probably disable build notifications from the webhook in Discord.

This also adds a streamlined guide on how to build the project and makes it reproducible if something does not work. There is no cost for public repositories.

## Most importantly
With the growing number of users and issues that can occur, it is best to have a way to share APKs from a trusted source so anyone can try a fix. 