### PR TITLE
fixes escaping

### DIFF
--- a/app/lib/core/sph/session.dart
+++ b/app/lib/core/sph/session.dart
@@ -8,6 +8,7 @@ import 'package:dio_cookie_manager/dio_cookie_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:html/dom.dart';
 import 'package:html/parser.dart';
+import 'package:html_unescape/html_unescape.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sph_plan/applets/definitions.dart';
 import 'package:sph_plan/core/database/account_database/account_db.dart';
@@ -42,6 +43,7 @@ class SessionHandler {
   SessionHandler({required this.sph, String? withLoginURL,});
 
   Future<void> prepareDio() async {
+    final unescape = HtmlUnescape();
     jar = CookieJar();
     dio.httpClientAdapter = getNativeAdapterInstance();
     dio.interceptors.add(CookieManager(jar));
@@ -60,6 +62,14 @@ class SessionHandler {
           connectionChecker.status = ConnectionStatus.disconnected;
         }
         return handler.next(error);
+      },
+    ));
+    dio.interceptors.add(InterceptorsWrapper(
+     onResponse: (Response response, ResponseInterceptorHandler handler) {
+       if (response.data is String) {
+         response.data = unescape.convert(response.data);
+       }
+       return handler.next(response);
       },
     ));
     dio.interceptors.add(InterceptorsWrapper(

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -78,6 +78,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
   flutter_masonry_view: ^0.0.2
   quick_actions: ^1.1.0
+  html_unescape: ^2.0.0
 
   # TODO: Temporary migration to flutter_secure_storage. Please remove this in the future.
   flutter_keychain:


### PR DESCRIPTION
Fixes #339.

This escapes all symbols on an app layer, as it seems like they are unescaped at many places. It does not really hurt performance:

```
I/flutter ( 5170): Response Size: 743
I/flutter ( 5170): Took to unescape: 47μs
I/flutter ( 5170): Response Size: 375251
I/flutter ( 5170): Took to unescape: 1697μs
I/flutter ( 5170): Response Size: 50979
I/flutter ( 5170): Took to unescape: 6332μs
```

In my tests the biggest time I have encountered is 8ms for e.g. my substitutions (which you know are pretty big). So there should be little to no difference.

In theory unescaping could break JSON payloads though, so this would need testing, but all functions that are available to me work. 