### PR TITLE
Implement account deletion and add devtools options configuration

### DIFF
--- a/app/devtools_options.yaml
+++ b/app/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/app/lib/core/database/account_database/account_db.dart
+++ b/app/lib/core/database/account_database/account_db.dart
@@ -262,6 +262,15 @@ class AccountDatabase extends _$AccountDatabase {
     return account.isNotEmpty;
   }
 
+  Future<void> deleteAllAccounts() async {
+    await delete(accountsTable).go();
+    final tempDir = await getTemporaryDirectory();
+    final userDir = Directory(tempDir.path);
+    if (userDir.existsSync()) {
+      userDir.deleteSync(recursive: true);
+    }
+  }
+
   static QueryExecutor _openConnection() {
     return driftDatabase(name: 'accounts_database');
   }


### PR DESCRIPTION
Due to the switch of apple developer accounts the keychain is unavoidable lost. Therefore all users have to be logged out of the old version.