### PR TITLE
Exclude Google Spyware from Android Build

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -77,6 +77,12 @@ android {
         }
     }
 
+    // Exclude just to be safe
+    configurations {
+        all*.exclude group: 'com.google.android.gms'
+        all*.exclude group: 'com.google.android.datatransport'
+    }
+
 }
 
 flutter {

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -76,7 +76,10 @@ dependencies:
   flutter_masonry_view: ^0.0.2
   quick_actions: ^1.1.0
   image_picker: ^1.1.2
-  flutter_doc_scanner: ^0.0.16
+  flutter_doc_scanner:
+    git:
+      url: https://github.com/lanis-mobile/flutter_doc_scanner_ios_only
+      ref: 1679a59
   pdf: ^3.11.3
   html_unescape: ^2.0.0
 


### PR DESCRIPTION
Excludes GMS and datatransport. 
Also completely removes the Android project from flutter_doc_scanner (to prevent MLKit from being depended on).

Closes #426